### PR TITLE
72 move syntax specifications to yaml

### DIFF
--- a/bin/pull-syntax
+++ b/bin/pull-syntax
@@ -5,34 +5,43 @@ import argparse
 
 import jinja2
 import jmespath
+import markdown
 import yaml
 
 
-
-template = jinja2.Template(source="""<table class="syntax">
+table_template = """<table class="syntax">
   {%- for sdata in syntax_data %}
     {% if sdata["name"] %}<tr><th class="section" colspan=2>{{sdata["name"]}}</th></tr>{% endif %}
     <tr><th>Syntax</th> <td><code>{{sdata["syntax"]}}</code></td> </tr>
-    <tr><th>Examples</th> <td><ul>{% for ex in sdata["examples"] %}<li><code>{{ex}}</code>{% endfor %}</ul></td> </tr>
+    {% if sdata["notes"] %}<tr><th></th> <td><ul>{% for n in sdata["notes"] %}<li>{{n|markdown}}</li>{% endfor %}</ul></td></tr>{% endif %}
+    <tr class="examples"><th>Examples</th> <td><ul>{% for ex in sdata["examples"] %}<li><code>{{ex}}</code>{% endfor %}</ul></td> </tr>
   {%- endfor %}
 </table>
 
 See [explanation of grammar syntax and common grammar elements](/recommendations/grammar) for elaboration
 """
-)
 
 
 def parse_args(args = None):
-    ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("ELEMENT", help="name of block to extract, e.g., dna.deletion")
-    ap.add_argument("--syntax-file", "-f", required=True)
-    opts = ap.parse_args(args=args)
-    return opts
+  ap = argparse.ArgumentParser(description=__doc__)
+  ap.add_argument("ELEMENT", help="name of block to extract, e.g., dna.deletion")
+  ap.add_argument("--syntax-file", "-f", required=True)
+  opts = ap.parse_args(args=args)
+  return opts
 
 
 if __name__ == "__main__":
-    opts = parse_args()
-    all_syntax_data = yaml.safe_load(open(opts.syntax_file))
-    path_ex = jmespath.compile(opts.ELEMENT)
-    syntax_data = path_ex.search(all_syntax_data)
-    print(template.render(syntax_data=syntax_data))
+  md = markdown.Markdown()
+  env = jinja2.Environment()
+  env.filters['markdown'] = lambda text: md.convert(text)
+  env.trim_blocks = True
+  env.lstrip_blocks = True
+
+  opts = parse_args()
+
+  all_syntax_data = yaml.safe_load(open(opts.syntax_file))
+  path_ex = jmespath.compile(opts.ELEMENT)
+  syntax_data = path_ex.search(all_syntax_data)
+  if not syntax_data:
+    raise RuntimeError(f"{opts.ELEMENT} not defined in {opts.syntax_file}")
+  print(env.from_string(table_template).render(syntax_data=syntax_data))

--- a/bin/pull-syntax
+++ b/bin/pull-syntax
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""extract one syntax definition from yaml file, as html table"""
+
+import argparse
+
+import jinja2
+import jmespath
+import yaml
+
+
+
+template = jinja2.Template(source="""<table class="syntax">
+  {%- for sdata in syntax_data %}
+    {% if sdata["name"] %}<tr><th class="section" colspan=2>{{sdata["name"]}}</th></tr>{% endif %}
+    <tr><th>Syntax</th> <td><code>{{sdata["syntax"]}}</code></td> </tr>
+    <tr><th>Examples</th> <td><ul>{% for ex in sdata["examples"] %}<li><code>{{ex}}</code>{% endfor %}</ul></td> </tr>
+  {%- endfor %}
+</table>
+
+See [explanation of grammar syntax and common grammar elements](/recommendations/grammar) for elaboration
+"""
+)
+
+
+def parse_args(args = None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("ELEMENT", help="name of block to extract, e.g., dna.deletion")
+    ap.add_argument("--syntax-file", "-f", required=True)
+    opts = ap.parse_args(args=args)
+    return opts
+
+
+if __name__ == "__main__":
+    opts = parse_args()
+    all_syntax_data = yaml.safe_load(open(opts.syntax_file))
+    path_ex = jmespath.compile(opts.ELEMENT)
+    syntax_data = path_ex.search(all_syntax_data)
+    print(template.render(syntax_data=syntax_data))

--- a/docs/recommendations/DNA/alleles.md
+++ b/docs/recommendations/DNA/alleles.md
@@ -6,9 +6,48 @@ Allele: a series of variants on one chromosome.
 
 ## Syntax
 
+<table class="syntax">
+<tr><th class="section" colspan=2>Variants in <i>cis</i></th></tr>
+<tr>
+<th>Syntax</th>
+<td><code>sequence_identifier ":" coordinate_type "." "[" position_edit ";" position_edit "]"</code></td>
+</tr>
+<tr>
+<th>Examples</th>
+<td><code>NC_000001.11:g.[123G>A;345del]</code></td>
+</tr>
+
+<tr><th class="section" colspan=2>Variants in <i>trans</i></th></tr>
+<tr>
+<th>Syntax</th>
+<td><code>sequence_identifier ":" coordinate_type "." "[" position_edit "]" ";" "[" position_edit "]"</code></td>
+</tr>
+<tr>
+<th>Examples</th>
+<td><code>NC_000001.11:g.[123G>A];[345del]</code></td>
+</tr>
+
+<tr><th class="section" colspan=2>Variants with unknown or uncertain phase</th></tr>
+<tr>
+<th>Syntax</th>
+<td><code>sequence_identifier ":" coordinate_type "." "[" position_edit "(;)" position_edit"]"</code></td>
+</tr>
+<tr>
+<th>Examples</th>
+<td><code>NC_000001.11:g.[123G>A(;)345del]</code></td>
+</tr>
+</table>
+
+<hr/>
+
+Pulled from syntax:
+
 ```sh exec="true"
 bin/pull-syntax -f docs/syntax.yaml dna.alleles
 ```
+
+- `position_edit` = any g. position-edit, such as [deletion](./deletion.md), [insertion](./insertion.md), or [deletion-insertion](./delins.md)
+- See [explanation of grammar syntax and common grammar elements](../grammar.md) for elaboration
 
 ## Notes
 

--- a/docs/recommendations/DNA/alleles.md
+++ b/docs/recommendations/DNA/alleles.md
@@ -6,37 +6,9 @@ Allele: a series of variants on one chromosome.
 
 ## Syntax
 
-<table class="syntax">
-<tr><th class="section" colspan=2>Variants in <i>cis</i></th></tr>
-<tr>
-<th>Syntax</th>
-<td><code>accession ":" type "." "[" posedit ";" posedit "]"</code></td>
-</tr>
-<tr>
-<th>Examples</th>
-<td><code>NC_000001.11:g.[123G>A;345del]</code></td>
-</tr>
-
-<tr><th class="section" colspan=2>Variants in <i>trans</i></th></tr>
-<tr>
-<th>Syntax</th>
-<td><code>accession ":" type "." "[" posedit "]" ";" "[" posedit "]"</code></td>
-</tr>
-<tr>
-<th>Examples</th>
-<td><code>NC_000001.11:g.[123G>A];[345del]</code></td>
-</tr>
-
-<tr><th class="section" colspan=2>Variants with unknown or uncertain phase</th></tr>
-<tr>
-<th>Syntax</th>
-<td><code>accession ":" type "." "[" posedit "(;)" posedit"]"</code></td>
-</tr>
-<tr>
-<th>Examples</th>
-<td><code>NC_000001.11:g.[123G>A(;)345del]</code></td>
-</tr>
-</table>
+```sh exec="true"
+bin/pull-syntax -f docs/syntax.yaml dna.alleles
+```
 
 ## Notes
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -122,6 +122,16 @@ table.syntax th.section {
   color: var(--md-typeset-a-color);
 }
 
+table.syntax ul {
+  margin: 0 !important;
+  padding: 0;
+  list-style-type: none;
+}
+
+table.syntax li {
+  margin: 0 !important;
+}
+
 /*
 === genetic code table
 */

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -125,10 +125,16 @@ table.syntax th.section {
 table.syntax ul {
   margin: 0 !important;
   padding: 0;
+}
+table.syntax tr.examples ul {
   list-style-type: none;
 }
 
-table.syntax li {
+table.syntax p {
+  margin: 0 !important;
+}
+
+table.syntax tr.examples li {
   margin: 0 !important;
 }
 

--- a/docs/syntax.yaml
+++ b/docs/syntax.yaml
@@ -1,0 +1,25 @@
+dna:
+  delins:
+    - syntax: sequence_identifier ":" coordinate_type "." position "delins" sequence
+      examples:
+        - NC_000001.11:g.123_129delinsAC
+  alleles:
+    - name: Variants in <i>cis</i>
+      syntax: accession ":" type "." "[" posedit ";" posedit "]"
+      examples:
+        - NC_000001.11:g.[123G>A;345del]
+        - JUSTANEXAMPLE.11:g.[123G>A(;)345del]
+        - JUSTANEXAMPLE.11:g.[123G>A(;)345del]
+        - JUSTANEXAMPLE.11:g.[123G>A(;)345del]
+        - JUSTANEXAMPLE.11:g.[123G>A(;)345del]
+    - name: Variants in <i>trans</i>
+      syntax: accession ":" type "." "[" posedit "]" ";" "[" posedit "]"
+      examples:
+        - NC_000001.11:g.[123G>A];[345del]
+        - JUSTANEXAMPLE.11:g.[123G>A(;)345del]
+        - JUSTANEXAMPLE.11:g.[123G>A(;)345del]
+    - name: Variants with unknown or uncertain phase
+      syntax: accession ":" type "." "[" posedit "(;)" posedit"]"</code></td>
+      examples:
+        - NC_000001.11:g.[123G>A(;)345del]
+        - JUSTANEXAMPLE.11:g.[123G>A(;)345del]

--- a/docs/syntax.yaml
+++ b/docs/syntax.yaml
@@ -6,6 +6,9 @@ dna:
   alleles:
     - name: Variants in <i>cis</i>
       syntax: accession ":" type "." "[" posedit ";" posedit "]"
+      notes:
+        - This is a note
+        - "`grammarelement` needs to be quoted"
       examples:
         - NC_000001.11:g.[123G>A;345del]
         - JUSTANEXAMPLE.11:g.[123G>A(;)345del]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,11 +7,12 @@ site_name: "HGVS Nomenclature"
 plugins:
   #- autolinks
   - awesome-pages
-  - glightbox
+  # - glightbox
+  - markdown-exec
   #- mermaid2
+  #- multirepo # https://github.com/backstage/mkdocs-monorepo-plugin
   - search
   - table-reader
-  #- multirepo # https://github.com/backstage/mkdocs-monorepo-plugin
   - macros # must be after table-reader
 
 markdown_extensions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
+jinja2
+jmespath
 markdown-captions
+markdown-exec
 mkdocs
 mkdocs-autolinks-plugin
 mkdocs-awesome-pages-plugin
@@ -10,3 +13,4 @@ mkdocs-mermaid2-plugin
 mkdocs-multirepo-plugin
 mkdocs-table-reader-plugin
 pre-commit
+pyyaml


### PR DESCRIPTION
This PR is a proposal to move the syntax blocks from specific recommendation files to a consolidated file with definitions. The advantages are:

- moves toward treating the syntax as source (rather than just text in markdown)
- helps to further standardize the structure of presentation
- enables new presentations, such as a matrix of {dna,rna,aa} ⊗ variant types. 

There is no change to the docs build process.

This screenshot shows the rendering:
![image](https://github.com/HGVSnomenclature/hgvs-nomenclature/assets/109453/14ab8d4d-d538-4371-894c-458aa0395075)

This PR does *not* update recommendations. Instead, if we choose to merge this PR, we'll merge main into existing change branches (#70 , #71) and adapt there.

P.S. Please ignore the posedit and other syntax details; they are irrelevant for this PR. 