### PR TITLE
Update the formatting of the RNA pages.

### DIFF
--- a/docs/recommendations/RNA/deletion.md
+++ b/docs/recommendations/RNA/deletion.md
@@ -22,25 +22,25 @@ bin/pull-syntax -f docs/syntax.yaml rna.deletion
 - the "position(s)\_deleted" should contain **two different positions**, e.g. 123_126 but not 123_123.
 - the "position(s)\_deleted" should be listed from **5' to 3'**, e.g. 123_126 but not 126_123.
 - for all descriptions the **most 3' position** possible of the reference sequence is arbitrarily assigned to have been changed (**3'rule**)
-  - the 3'rule also applies for changes in single residue stretches and tandem repeats (nucleotide or amino acid): **NOTE:** the exception to the 3'rule for deletions around exon/exon junctions see [Deletions](../DNA/deletion.md) does not apply when describing variants based on a RNA reference sequence
-- † = see [Uncertain](../uncertain.md); when the postion and/or the sequence of a deletion has not been defined, a description may have a format like r.(100_150)del(15)
+  - the 3'rule also applies for changes in single residue stretches and tandem repeats (nucleotide or amino acid). **NOTE:** the exception to the 3'rule for deletions around exon/exon junctions see [Deletions](../DNA/deletion.md) does not apply when describing variants based on a RNA reference sequence.
+- † = see [Uncertain](../uncertain.md); when the postion and/or the sequence of a deletion has not been defined, a description may have a format like `r.(100_150)delN[15]`.
 
 ## Examples
 
 - one nucleotide
-  - LRG_199t1:r.10del: a deletion of the U at position r.10 in the reference sequence LRG_199t1
+  - `LRG_199t1:r.10del`: a deletion of the U at position r.10 in the reference sequence LRG_199t1
 - several nucleotides
-  - NM_004006.2:r.6_8del: a deletion of nucleotides r.6 to r.8 in the reference sequence NM_004006.2: **NOTE**: it is allowed to describe the variant as r.6_8deluug
-  - LRG_2t1:r.1034_1036del: a deletion of nucleotides r.1034 to r.1036 ("uug") in the reference sequence LRG_2t1: **NOTE**: since the 3'rule has to be applied the variant, crossing the intron between nucleotides r.1035 and r.1036, is **not** described as r.1033_1035del (deletion "guu")
-  - LRG_199t1:r.(4072_5145del): the predicted deletion of exon 30 (starting at position r.4072) to exon 36 (ending at position r.5145) of the DMD-gene; RNA has **not been analysed**
-- LRG_199t1:r.=/6_8del: a mosaic case where from position r.6 to r.8 besides the normal sequence also transcripts are found containing a deletion of this sequence: **NOTE**: for the predicted consequences of a variant the description is LRG_199t1:r.(6_8del)
+  - `NM_004006.2:r.6_8del`: a deletion of nucleotides r.6 to r.8 in the reference sequence NM_004006.2. **NOTE**: it is allowed to describe the variant as <code class="invalid">r.6_8deluug</code>.
+  - `LRG_2t1:r.1034_1036del`: a deletion of nucleotides r.1034 to r.1036 ("uug") in the reference sequence LRG_2t1. **NOTE**: since the 3'rule has to be applied the variant, crossing the intron between nucleotides r.1035 and r.1036, is **not** described as <code class="invalid">r.1033_1035del</code> (deletion "guu").
+  - `LRG_199t1:r.(4072_5145del)`: the predicted deletion of exon 30 (starting at position r.4072) to exon 36 (ending at position r.5145) of the DMD-gene; RNA has **not been analysed**
+- `LRG_199t1:r.=/6_8del`: a mosaic case where from position r.6 to r.8 besides the normal sequence also transcripts are found containing a deletion of this sequence. **NOTE**: for the predicted consequences of a variant the description is `LRG_199t1:r.(6_8del)`.
 
 ## Discussion
 
-!!! note "Can I use r.123del6 to describe a 6 nucleotide deletion?"
+!!! note "Can I use <code class="invalid">r.123del6</code> to describe a 6 nucleotide deletion?"
 
-    No, a deletion of more than one residue should mention the first and last residue deleted, separated using the range symbol ("_", underscore), e.g. r.123_128del and not r.123del6.
+    No, a deletion of more than one residue should mention the first and last residue deleted, separated using the range symbol ("_", underscore), e.g. `r.123_128del` and not <code class="invalid">r.123del6</code>.
 
-!!! note "Is the description of a deletion of exon 17 as r.EX17del still allowed?"
+!!! note "Is the description of a deletion of exon 17 as <code class="invalid">r.EX17del</code> still allowed?"
 
-    A description like r.EX17del has never been allowed. Descriptions should be specific and indicate the nucleotides affected by the change.
+    A description like <code class="invalid">r.EX17del</code> has never been allowed. Descriptions should be specific and indicate the nucleotides affected by the change.

--- a/docs/recommendations/RNA/delins.md
+++ b/docs/recommendations/RNA/delins.md
@@ -22,26 +22,26 @@ bin/pull-syntax -f docs/syntax.yaml rna.delins
 - **prefix** reference sequences accepted are r. (coding and non-coding RNA).
 - by definition, when **one** nucleotide is replaced by **one** other nucleotide the change is a [substitution](substitution.md).
 - two variants separated by one or more nucleotides should preferably be described individually and **not** as a "delins"
-  - exception: two variants separated by one nucleotide, together affecting one amino acid, should be described as a "delins" (e.g. r.142_144delinsugg p.(Arg48Trp)).: **NOTE:** this prevents tools predicting the consequences of a variant to make conflicting and incorrect predictions of two different substitutions at one position
+  - exception: two variants separated by one nucleotide, together affecting one amino acid, should be described as a "delins" (e.g. `r.142_144delinsugg` `p.(Arg48Trp)`). **NOTE:** this prevents tools predicting the consequences of a variant to make conflicting and incorrect predictions of two different substitutions at one position.
   - **conversions**, a sequence change where a range of nucleotides are replaced by a sequence from elsewhere in the genome, are described as a "delins". The previous format "con" is no longer used (see [Community Consultation SVD-WG009)](../../consultation/SVD-WG009.md)).
-- RNA-fusion transcripts represent a special case of deletion-insertion variant. The fusion break point is described using **"::"**: **NOTE:** to avoid confusion, HGVS recommends to follow the [HGNC guidelines](https://www.genenames.org/about/guidelines/) to describe products of gene translocations or fusions (format GENESYMBOL1::GENESYMBOL2) and readthrough transcripts (format GENESYMBOL1-GENESYMBOL2)
+- RNA-fusion transcripts represent a special case of deletion-insertion variant. The fusion break point is described using **"::"**. **NOTE:** to avoid confusion, HGVS recommends to follow the [HGNC guidelines](https://www.genenames.org/about/guidelines/) to describe products of gene translocations or fusions (format GENESYMBOL1::GENESYMBOL2) and readthrough transcripts (format GENESYMBOL1-GENESYMBOL2).
 - for all descriptions the **most 3' position** possible of the reference sequence is arbitrarily assigned to have been changed (**3'rule**)
 
 ## Examples
 
-- r.775delinsga: a deletion of nucleotide r.775 (a "u", not described), replaced by nucleotides "ga", changing ..aggc<code class="spot1">u</code>cauu.. to ..aggc<code class="spot1">ga</code>cauu..
-- r.775_777delinsc : a deletion of nucleotides r.775 to r.777 ("uca", not described), replaced by nucleotides "c", changing ..aggc<code class="spot1">uca</code>uu.. to ..aggc<code class="spot1">c</code>uu..
-- r.902_909delinsuuu: a deletion of nucleotides r.902 to r.909, replaced by nucleotides uuu
-- r.142_144delinsugg (p.Arg48Trp): a deletion replacing nucleotides r.142 to r.144 (cga, not described) with ugg: **NOTE:** the variant can also be described as r.[142c>u;144a>g], i.e. two substitutions. This format is preferred when either of the two variants is known as a frequently occurring variant ("polymorphism")
+- `r.775delinsga`: a deletion of nucleotide r.775 (a "u", not described), replaced by nucleotides "ga", changing <code>..aggc<code class="del">u</code>cauu..</code> to <code>..aggc<code class="ins">ga</code>cauu..</code>.
+- `r.775_777delinsc` : a deletion of nucleotides r.775 to r.777 ("uca", not described), replaced by nucleotides "c", changing <code>..aggc<code class="del">uca</code>uu..</code> to <code>..aggc<code class="ins">c</code>uu..</code>.
+- `r.902_909delinsuuu`: a deletion of nucleotides r.902 to r.909, replaced by nucleotides uuu
+- `r.142_144delinsugg` (`p.Arg48Trp`): a deletion replacing nucleotides r.142 to r.144 (cga, not described) with ugg. **NOTE:** the variant can also be described as `r.[142c>u;144a>g]`, i.e. two substitutions. This format is preferred when either of the two variants is known as a frequently occurring variant ("polymorphism")
 - RNA conversion (based on [SVD-WG009](../../consultation/SVD-WG009.md))
-  - NM_004006.2:r.2623_2803delins2804_2949: conversion replacing nucleotides r.2623 to r.2803 (exon 21) with nucleotides r.2804 to r.2949 (exon 22) as found in the DMD coding RNA sequence file NM_004006.2
-  - r.415_1655delins[AC096506.5:g.409\_1649]: conversion replacing nucleotides r.414 to r.1655 with nucleotides 409 to 1649 as found in the genomic reference sequence AC096506.5
-  - r.1401_1446delins[NR\_002570.3:r.1513\_1558]: conversion in exon 9 of the CYP2D6 gene replacing exon 9 nucleotides r.1401 to r.1446 with those of the 3' flanking CYP2D7P1 gene, nucleotides r.1513 to r.1558
+  - `NM_004006.2:r.2623_2803delins2804_2949`: conversion replacing nucleotides r.2623 to r.2803 (exon 21) with nucleotides r.2804 to r.2949 (exon 22) as found in the DMD coding RNA sequence file NM_004006.2
+  - `r.415_1655delins[AC096506.5:g.409_1649]`: conversion replacing nucleotides r.414 to r.1655 with nucleotides 409 to 1649 as found in the genomic reference sequence AC096506.5
+  - `r.1401_1446delins[NR_002570.3:r.1513_1558]`: conversion in exon 9 of the CYP2D6 gene replacing exon 9 nucleotides r.1401 to r.1446 with those of the 3' flanking CYP2D7P1 gene, nucleotides r.1513 to r.1558
 - RNA fusion transcripts (based on [SVD-WG007](../../consultation/SVD-WG007.md))
-  - translocation fusion: NM_152263.2:r.-115_775::NM_002609.3:r.1580\_\*1924 describes a TPM3::PDGFRB fusion transcript where nucleotides r.-115 to r.775 (reference transcript NM_152263.2, TPM3 gene) are coupled to nucleotides r.1580 to r.\*1924 (reference transcript NM_002609.3, PDGFRB gene)
+  - translocation fusion: `NM_152263.2:r.-115_775::NM_002609.3:r.1580_*1924` describes a TPM3::PDGFRB fusion transcript where nucleotides r.-115 to r.775 (reference transcript NM_152263.2, TPM3 gene) are coupled to nucleotides r.1580 to r.\*1924 (reference transcript NM_002609.3, PDGFRB gene)
   - **deletion fusion**
-    - NM_002354.2:r.-358_555::NM_000251.2:r.212\_\*279: describes an EPCAM::MSH2 fusion transcript where nucleotides r.-358 to r.555 (reference transcript NM_002354.2, EPCAM gene) are coupled to nucleotides r.212 to r.\*279 (reference transcript NM_000251.2, MSH2 gene)
-    - NM_002354.2:r.?\_555::guaugauuuuuuaataa::NM_000251.2:r.212\_?: describes an EPCAM::MSH2 fusion transcript where only the fusion break point has been characterised, showing the insertion of a 17 nucletoide sequence (guaugauuuuuuaataa) between two fusion transcripts
+    - `NM_002354.2:r.-358_555::NM_000251.2:r.212_*279`: describes an EPCAM::MSH2 fusion transcript where nucleotides r.-358 to r.555 (reference transcript NM_002354.2, EPCAM gene) are coupled to nucleotides r.212 to r.\*279 (reference transcript NM_000251.2, MSH2 gene)
+    - `NM_002354.2:r.?_555::guaugauuuuuuaataa::NM_000251.2:r.212_?`: describes an EPCAM::MSH2 fusion transcript where only the fusion break point has been characterised, showing the insertion of a 17 nucletoide sequence (guaugauuuuuuaataa) between two fusion transcripts
 
 ## Discussion
 
@@ -49,10 +49,10 @@ bin/pull-syntax -f docs/syntax.yaml rna.delins
 
     The term "indel" is not used in HGVS nomenclature (see [Glossary](../../background/glossary.md). The term is confusing, having different meanings in different disciplines.
 
-!!! note "Can I describe a "gc" to "ug" variant as a dinucleotide substitution (r.4gc>ug)?"
+!!! note "Can I describe a "gc" to "ug" variant as a dinucleotide substitution (<code class="invalid">r.4gc>ug</code>)?"
 
-    No this is not allowed. By definition a substitution changes **one** nucleotide into **one** other nucleotide (see [Substitution](http://www.HGVS.org/varnomen/recommendations/RNA/variant/substitution/)). The change "augu<code class="spot1">gc</code>ca" to 'augu<code class="spot1">ug</code>ca" should be described as r.5_6delinsug, i.e. a deletion/insertion (indel).
+    No this is not allowed. By definition a substitution changes **one** nucleotide into **one** other nucleotide (see [Substitution](http://www.HGVS.org/varnomen/recommendations/RNA/variant/substitution/)). The change <code>augu<code class="del">gc</code>ca</code> to <code>augu<code class="ins">ug</code>ca</code> should be described as `r.5_6delinsug`, i.e. a deletion/insertion (indel).
 
-!!! note "The BRCA1 coding RNA reference sequence from position r.2074 to r.2080 is ..caugaca.. A variant frequently found in the population is ..cau<code class="spot1">a</code>aca.. (r.2077g>a). In a patient I found the sequence ..cau<code class="spot1">a ua</code>aca.. Can I describe this variant as r.[2077g>a;2077_2078insua]?"
+!!! note "The BRCA1 coding RNA reference sequence from position r.2074 to r.2080 is `caugaca`. A variant frequently found in the population is <code>cau<code class="sub">a</code>aca</code> (`r.2077g>a`). In a patient I found the sequence <code>cau<code class="sub">a</code><code class="ins">ua</code>aca</code>. Can I describe this variant as <code class="invalid">r.[2077g>a;2077_2078insua]</code>?"
 
-    The shortest description of this variant is r.2077delinsaua. However, since the variant is likely a combination of two other variants it is acceptable to describe it as r.[2077g>a;2077_2078insua].
+    The shortest description of this variant is `r.2077delinsaua`. However, since the variant is likely a combination of two other variants it is acceptable to describe it as <code class="invalid">r.[2077g>a;2077_2078insua]</code>.

--- a/docs/recommendations/RNA/duplication.md
+++ b/docs/recommendations/RNA/duplication.md
@@ -24,15 +24,15 @@ bin/pull-syntax -f docs/syntax.yaml rna.duplication
 - by definition, duplication may only be used when the additional copy is **directly 3'-flanking** of the original copy (a "tandem duplication").
   - when a variant can be described as a duplication it **must** be desribed as a duplication and not as e.g. an insertion (see [Prioritization](../general.md))
   - when there is no evidence that the extra copy of a sequence detected is in tandem (directly 3'-flanking) the original copy, the change can not be described as a duplication, it should be described as **an insertion** (see [Insertion](insertion.md)).
-  - **inverted duplications** are described as insertion (r.234_235ins123_234inv), not as a duplication (see [Inversion](inversion.md))
+  - **inverted duplications** are described as insertion (`r.234_235ins123_234inv`), not as a duplication (see [Inversion](inversion.md))
 - for all descriptions the **most 3' position** possible of the reference sequence is arbitrarily assigned to have been changed (**3'rule**)
   - the 3'rule also applies for changes in single residue stretches and tandem repeats
   - **NOTE:** the exception to the 3'rule for duplications around exon/exon junctions see [Duplications](../DNA/duplication.md) does not apply when describing variants based on a RNA reference sequence
 
 ## Examples
 
-- r.7dup (one nucleotide): the duplication of a "u" at position r.7 in the sequence ..acuuacugcc.. to ..acuuacu<code class="spot1">u</code>gcc..: **NOTE**: it is **not** allowed to describe the variant as r.6_7insu (see [prioritisation](../general.md))
-- r.6_8dup (several nucleotides): a duplication from position r.6 to r.8 in the sequence ..acaauugcc.. to ..acaauugc<code class="spot1">ugc</code>c..: **NOTE**: it is allowed to describe the variant as g.6_8dupugc
+- `r.7dup` (one nucleotide): the duplication of a "u" at position r.7 in the sequence <code>acuuacu<code class="ins">u</code>gcc</code>. **NOTE**: it is **not** allowed to describe the variant as <code class="invalid">r.6_7insu</code> (see [prioritisation](../general.md))
+- `r.6_8dup` (several nucleotides): a duplication from position r.6 to r.8 in the sequence <code>acaauugc<code class="ins">ugc</code>c</code>. **NOTE**: it is allowed to describe the variant as <code class="invalid">g.6_8dupugc</code>.
 
 ## Discussion
 
@@ -43,8 +43,8 @@ bin/pull-syntax -f docs/syntax.yaml rna.duplication
     - the description is simple and shorter
     - it is clear and prevents confusion regarding the position when an insertion is incorrectly reported like "22insg"
 
-!!! note "How should I describe the change "aucg**aucgaucgauc**aggguccc" to "aucg**aucgaucgauc**a**aucgaucgauc**ggguccc"? The fact that the inserted sequence (aucgaucgauc) is present in the original sequence suggests it derives from a duplicative event."
+!!! note "How should I describe the change <code>aucg<code class="spot1">aucgaucgauc</code>aggguccc</code> to <code>aucg<code class="spot1">aucgaucgauc</code>a<code class="ins">aucgaucgauc</code>ggguccc</code>? The fact that the inserted sequence (aucgaucgauc) is present in the original sequence suggests it derives from a duplicative event."
 
-    The variant should be described as an insertion; r.17_18ins5_16. A description using "dup" is not correct since, by definition, a duplication should be **directly 3'-flanking of the original copy** (in tandem). Note that the description given still makes it clear that the sequence inserted between r.17 and r.18 is probably derived from nearby, i.e. position r.5 to r.16, and thus likely derived from a duplicative event.
+    The variant should be described as an insertion; `r.17_18ins5_16`. A description using "dup" is not correct since, by definition, a duplication should be **directly 3'-flanking of the original copy** (in tandem). Note that the description given still makes it clear that the sequence inserted between r.17 and r.18 is probably derived from nearby, i.e. position r.5 to r.16, and thus likely derived from a duplicative event.
 
 ---

--- a/docs/recommendations/RNA/insertion.md
+++ b/docs/recommendations/RNA/insertion.md
@@ -23,33 +23,33 @@ bin/pull-syntax -f docs/syntax.yaml rna.insertion
   - the "positions_flanking" should be listed from 5' to 3', e.g. 123_124 not 124_123
 - when a variant can be described as a duplication it **must** be desribed as a duplication and **not as an insertion** (see [Prioritization](../general.md)
 - for all descriptions the **most 3' position** possible of the reference sequence is arbitrarily assigned to have been changed (**3'rule**)
-- the **"inserted_sequence"** can be given as the nucleotides inserted (e.g. insAGC) or, for larger insert sequences, by referring to the sequence in the reference sequence (e.g. c.849_850ins858_895) or another reference (see Examples).
-  - when the inserted sequence is very long, it can best be submitted to a database (e.g. [GenBank](http://www.ncbi.nlm.nih.gov/genbank/submit/)); the accession.version number obtained can then be used to describe the variant, like r.123_124ins[L37425.1:r.23\_361].
-- † = see [Uncertain](../uncertain.md); when the postion and/or the sequence of an inserted sequence has not been defined, a description may have a format like r.(100_150)ins(25)
+- the **"inserted_sequence"** can be given as the nucleotides inserted (e.g. insagc) or, for larger insert sequences, by referring to the sequence in the reference sequence (e.g. `r.849_850ins858_895`) or another reference (see Examples).
+  - when the inserted sequence is very long, it can best be submitted to a database (e.g. [GenBank](http://www.ncbi.nlm.nih.gov/genbank/submit/)); the accession.version number obtained can then be used to describe the variant, like `r.123_124ins[L37425.1:r.23_361]`.
+- † = see [Uncertain](../uncertain.md); when the postion and/or the sequence of an inserted sequence has not been defined, a description may have a format like `r.(100_150)insn[25]`.
 
 ## Examples
 
-- LRG_199t1:r.426_427insa: the insertion of an "a" nucleotide between nucleotides r.426 and r.427
-- LRG_199t1:r.756_757insuacu: the insertion of nucleotides "uacu" between nucleotides r.756 and r.757
-- NM_004006.2:r.(222_226)insg (p.Asn75fs): the insertion of a "g" at an unknown position in the sequence encoding amino acid 75
-- NM_004006.2:r.549_550insn : the insertion of one not specified nucleotide (n) between position r.549 and r.550
-- NM_004006.2:r.761_762insnnnnn (alternatively r.761_762insn[5]): the insertion of 5 not specified nucleotides (nnnnn) between position r.761 and r.762
-- LRG_199t1:r.1149_1150insn[100]: the insertion of 100 not specified nucleotides between position r.1149 and r.1150
-- NG_012232.1(NM_004006.2):r.2949_2950ins[2950-30\_2950-12;2950-4\_2950-1]: the insertion of intronic nucleotides r.2950-30 to r.2950-12 and r.2950-4 to r.2950-1 between nucleotides r.2949 and r.2950 (caused by the deletion NC_000023.10(NM_004006.2):c.2950-11_2950-5del]. Alternative description r.2949_2950ins[2950-30\_2950-12;uuag]
+- `LRG_199t1:r.426_427insa`: the insertion of an "a" nucleotide between nucleotides r.426 and r.427
+- `LRG_199t1:r.756_757insuacu`: the insertion of nucleotides "uacu" between nucleotides r.756 and r.757
+- `NM_004006.2:r.(222_226)insg` (`p.Asn75fs`): the insertion of a "g" at an unknown position in the sequence encoding amino acid 75
+- `NM_004006.2:r.549_550insn` : the insertion of one not specified nucleotide (n) between position r.549 and r.550
+- `NM_004006.2:r.761_762insnnnnn` (alternatively `r.761_762insn[5]`): the insertion of 5 not specified nucleotides (nnnnn) between position r.761 and r.762
+- `LRG_199t1:r.1149_1150insn[100]`: the insertion of 100 not specified nucleotides between position r.1149 and r.1150
+- <code class="invalid">NG_012232.1(NM_004006.2):r.2949_2950ins[2950-30_2950-12;2950-4_2950-1]</code>: the insertion of intronic nucleotides r.2950-30 to r.2950-12 and r.2950-4 to r.2950-1 between nucleotides r.2949 and r.2950 (caused by the deletion `NC_000023.10(NM_004006.2):c.2950-11_2950-5del`). Alternative description <code class="invalid">r.2949_2950ins[2950-30_2950-12;uuag]</code>.
   - **NOTE:** for more examples of variants affecting splicing see [Splicing](splicing.md)
 
 ## Discussion
 
-!!! note "Can I describe a variant as r.123insg?"
+!!! note "Can I describe a variant as <code class="invalid">r.123insg</code>?"
 
-    No, since the description is not unequivocal it is not allowed. What does the description mean, the insertion of a "g" **at** position 123 or the insertion of a "g" **after** position 123? The situation becomes even more complex when using a coding RNA reference sequence a "-" character is used, e.g. r.-14insG; when the insertion is **after** nucleotide r.-14, is this position r.-13 or r.-15?
+    No, since the description is not unequivocal it is not allowed. What does the description mean, the insertion of a "g" **at** position 123 or the insertion of a "g" **after** position 123? The situation becomes even more complex when using a coding RNA reference sequence a "-" character is used, e.g. <code class="invalid">r.-14insG</code>; when the insertion is **after** nucleotide r.-14, is this position r.-13 or r.-15?
 
 !!! note "Can I use the "^" character to describe an insertion?"
 
-    No, insertions can not be described using the format r.123ˆ124insu or r.123ˆ124u. The recommendations try to restrict the number of different characters used to a minimum. Since a character was already used to indicate a range (the *underscore*) a new character was not required.
+    No, insertions can not be described using the format <code class="invalid">r.123ˆ124insu</code> or <code class="invalid">r.123ˆ124u</code>. The recommendations try to restrict the number of different characters used to a minimum. Since a character was already used to indicate a range (the *underscore*) a new character was not required.
 
-!!! note "How should I describe the change "aucg**aucgaucgauc**aggguccc" to "aucg**aucgaucgauc**a**aucgaucgauc**ggguccc"? The fact that the inserted sequence (aucgaucgauc) is present in the original sequence suggests it derives from a duplicative event."
+!!! note "How should I describe the change <code>aucg<code class="spot1">aucgaucgauc</code>aggguccc</code> to <code>aucg<code class="spot1">aucgaucgauc</code>a<code class="ins">aucgaucgauc</code>ggguccc</code>? The fact that the inserted sequence (aucgaucgauc) is present in the original sequence suggests it derives from a duplicative event."
 
-    The variant should be described as an insertion; r.17_18ins5_16. A description using "dup" is not correct since, by definition, a duplication should be **directly 3'-flanking of the original copy** (in tandem). Note that the description given still makes it clear that the sequence inserted between r.17 and r.18 is probably derived from nearby, i.e. position r.5 to r.16, and thus likely derived from a duplicative event.
+    The variant should be described as an insertion; `r.17_18ins5_16`. A description using "dup" is not correct since, by definition, a duplication should be **directly 3'-flanking of the original copy** (in tandem). Note that the description given still makes it clear that the sequence inserted between r.17 and r.18 is probably derived from nearby, i.e. position r.5 to r.16, and thus likely derived from a duplicative event.
 
 ---

--- a/docs/recommendations/RNA/inversion.md
+++ b/docs/recommendations/RNA/inversion.md
@@ -19,27 +19,27 @@ bin/pull-syntax -f docs/syntax.yaml rna.inversion
 
 - all variants **should be** described at the DNA level, descriptions at the RNA and/or protein level may be given in addition
 - **prefix** reference sequences accepted are r. (coding and non-coding RNA)
-- by definition, the region inverted ("positions_inverted") contains **more then one nucleotide**. The description r.234inv is therefore not allowed; a one nucleotide inversion should be described as a [substitution](substitution.md)
+- by definition, the region inverted ("positions_inverted") contains **more then one nucleotide**. The description `r.234inv` is therefore not allowed; a one nucleotide inversion should be described as a [substitution](substitution.md)
 - for all descriptions the **most 3' position** possible of the reference sequence is arbitrarily assigned to have been changed (**3'rule**)
-- **inverted duplications** are described as an insertion using the format r.234_235ins123_234inv, not as r.123_456dupinv
+- **inverted duplications** are described as an insertion using the format `r.234_235ins123_234inv`, not as <code class="invalid">r.123_456dupinv</code>
 - since exon splice signals will be inverted, large genomic inversions on the RNA level usually give [deletion](deletion.md) or [deletion-insertion (indel)](delins.md) variants
 - inversions are not used on protein level. Depending on the (predicted) consequences of an inversion on protein level, changes are usually described as either a **delins** or a **frame shift**.
 
 ## Examples
 
-- r.177_180inv: inversion of nucleotides r.177 to r.180, changing ..agg**cuga**uu.. to ..agg<code class="spot1">ucag</code>uu..
-- r.203_506inv: inversion of the 304 nucleotides from position r.203 to r.506
+- `r.177_180inv`: inversion of nucleotides r.177 to r.180, changing <code>..agg<code class="del">cuga</code>uu..</code> to <code>..agg<code class="ins">ucag</code>uu..</code>
+- `r.203_506inv`: inversion of the 304 nucleotides from position r.203 to r.506
 
 ## Discussion
 
 !!! note "Is the change "aagc" to "uucg" an inversion?"
 
-    No, an inversion would change "aagc" to "gcuu", its **revese-complement**. "uucg" is only the **complement** of "aagc".
+    No, an inversion would change "aagc" to "gcuu", its **reverse-complement**. "uucg" is only the **complement** of "aagc".
 
 !!! note "Is the change "aagc" to "cgaa" an inversion?"
 
-    No, an inversion would change "aagc" to "gcuu", its **revese-complement**. CGAA is only the **reverse** of "aagc".
+    No, an inversion would change "aagc" to "gcuu", its **revese-complement**. "cgaa" is only the **reverse** of "aagc".
 
-!!! note "On the [old nomenclature website](http://www.HGVS.org/mutnomen/examplesRNA.html) (bottom) you had the example r.124_500delinsoAB053210.2:r.1289-365_1289-73, i.e. the "o" indicating the inserted sequence AB053210.2:r.1289-365_1289-73 was from the opposite transcriptional strand. Is the "o" still used?"
+!!! note "On the [old nomenclature website](http://www.HGVS.org/mutnomen/examplesRNA.html) (bottom) you had the example <code class="invalid">r.124_500delinsoAB053210.2:r.1289-365_1289-73</code>, i.e. the "o" indicating the inserted sequence AB053210.2:r.1289-365_1289-73 was from the opposite transcriptional strand. Is the "o" still used?"
 
-    No, the "o" is not used, the insertion is in an inverted orientation so "inv" should be used; r.124_500delinsAB053210.2:r.1289-365_1289-73inv.
+    No, the "o" is not used, the insertion is in an inverted orientation so "inv" should be used; <code class="invalid">r.124_500delins[AB053210.2:r.1289-365_1289-73inv]</code>.

--- a/docs/recommendations/RNA/substitution.md
+++ b/docs/recommendations/RNA/substitution.md
@@ -24,34 +24,34 @@ bin/pull-syntax -f docs/syntax.yaml rna.substitution
 - substitutions involving two or more consecutive nucleotides are described as deletion/insertions (indels) (see [Deletion/insertion (delins)](delins.md)).
 - two substitutions separated by one or more nucleotides should be described individually and not as a "delins"
   - exception: two variants separated by one nucleotide, together affecting one amino acid, should be described as a "delins" (e.g. r.142_144delinsugg (p.Arg48Trp)).: **NOTE:** this prevents tools predicting the consequences of a variant to make conflicting and incorrect predictions of two different substitutions at one position
-- nucleotides that have been tested and found **not changed** are described as r.109u=, r.4567_4569= (see [SVD-WG001 (no change)](http://www.hgvs.org/mutnomen/accepted001.html)).
-- it is not correct to describe "_polymorphisms_" as r.76a/g (see [Discussions](#polymorphism)).
+- nucleotides that have been tested and found **not changed** are described as `r.109u=`, `r.4567_4569=` (see [SVD-WG001 (no change)](http://www.hgvs.org/mutnomen/accepted001.html)).
+- it is not correct to describe "_polymorphisms_" as <code class="invalid">r.76a/g</code> (see [Discussions](#polymorphism)).
 
 ## Examples
 
-- NM_004006.3:r.76a>c: a substitution of the "a" nucleotide at r.76 with a "c"
-- NM_004006.3:r.76_77delinsug : **NOTE**: based on the definition of a substitution, i.e. **one** nucleotide replaced by **one** other nucleotide, this change can not be described as a substitution like r.76_77aa>ug or r.76aa>ug
-- NM_004006.3:r.(1388g>a): the predicted consequences at RNA level is a substitution of the "g" nucleotide at r.1388 with a "g"
-- NM_004006.3:r.123=: a screen was performed showing that nucleotide r.123 was a "c" as in the coding DNA reference sequence (the nucleotide was not changed).
-- NM_004006.1:r.-14a>c: a "a" to "c" substitution 14 nucleotides 5' of the ATG translation initiation codon
-- NM_004006.3:r.\*41u>a: a "u" to "a" substitution 41 nucleotides 3' of the translation termination codon
-- NM_004006.3:r.[897u>g,832\_960del]: two different transcripts, 897u>g and r.832_960del, derive from one variant (NM_004006.3:c.897T>G at the DNA level): **NOTE**: for more examples of variants affecting splicing see [RNA splicing](splicing.md)
-- NM_004006.1:r.0: no RNA from the variant allele could be detected
-- NM_004006.3:r.spl: RNA has not been analysed but it is very likely that splicing is affected
-- NM_004006.3:r.?: an effect on the RNA level is expected but it is not possible to give a reliable prediction of the consequences (RNA not analysed)
-- NM_004006.3:r.85=/u>c: a mosaic case where at position 85 besides the normal sequence (a U, described as "=") also transcripts are found containing a C (r.85u>c): **NOTE**: irrespective of the frequency in which each nucleotide was found, the reference is always described first
-- NM_004006.3:r.85=//u>c: a chimeric case, i.e. the sample is a mix of cells containing r.85= and r.85u>c.: **NOTE**: irrespective of the frequency in which each nucleotide was found, the reference is always described first
+- `NM_004006.3:r.76a>c`: a substitution of the "a" nucleotide at r.76 with a "c"
+- `NM_004006.3:r.76_77delinsug`: **NOTE**: based on the definition of a substitution, i.e. **one** nucleotide replaced by **one** other nucleotide, this change can not be described as a substitution like <code class="invalid">r.76_77aa>ug</code> or <code class="invalid">r.76aa>ug</code>
+- `NM_004006.3:r.(1388g>a)`: the predicted consequences at RNA level is a substitution of the "g" nucleotide at r.1388 with a "g"
+- `NM_004006.3:r.123=`: a screen was performed showing that nucleotide r.123 was a "c" as in the coding DNA reference sequence (the nucleotide was not changed).
+- `NM_004006.1:r.-14a>c`: a "a" to "c" substitution 14 nucleotides 5' of the ATG translation initiation codon
+- `NM_004006.3:r.*41u>a`: a "u" to "a" substitution 41 nucleotides 3' of the translation termination codon
+- `NM_004006.3:r.[897u>g,832_960del]`: two different transcripts, `r.897u>g` and `r.832_960del`, derive from one variant (`NM_004006.3:c.897T>G` at the DNA level). **NOTE**: for more examples of variants affecting splicing see [RNA splicing](splicing.md).
+- `NM_004006.1:r.0`: no RNA from the variant allele could be detected
+- `NM_004006.3:r.spl`: RNA has not been analysed but it is very likely that splicing is affected
+- `NM_004006.3:r.?`: an effect on the RNA level is expected but it is not possible to give a reliable prediction of the consequences (RNA not analysed)
+- `NM_004006.3:r.85=/u>c`: a mosaic case where at position 85 besides the normal sequence (a U, described as "=") also transcripts are found containing a C (`r.85u>c`). **NOTE**: irrespective of the frequency in which each nucleotide was found, the reference is always described first.
+- `NM_004006.3:r.85=//u>c`: a chimeric case, i.e. the sample is a mix of cells containing `r.85=` and `r.85u>c`. **NOTE**: irrespective of the frequency in which each nucleotide was found, the reference is always described first.
 
 ## Discussion
 
 !!! note "When I only sequenced RNA (cDNA) and not genomic DNA should I then give the description of a variant at DNA level in parenthesis?"
 
-    Yes, while the variant at RNA level can be described as r.76a>g on DNA level, based on a coding DNA reference, sequence it should be described as c.(76A>G).
+    Yes, while the variant at RNA level can be described as `r.76a>g` on DNA level, based on a coding DNA reference, sequence it should be described as `c.(76A>G)`.
 
-!!! note "<a id="polymorphism"></a>Are polymorphisms described like r.76a/g?"
+!!! note "<a id="polymorphism"></a>Are polymorphisms described like <code class="invalid">r.76a/g</code>?"
 
-    No, all substitutions are described as r.76a>g. In the past, the format r.76a/g has been used to describe "polymorphic" sequence variants. Note that a description should be neutral, simply describe the change, and not include any other information like predicted or known functional consequences.
+    No, all substitutions are described as `r.76a>g`. In the past, the format <code class="invalid">r.76a/g</code> has been used to describe "polymorphic" sequence variants. Note that a description should be neutral, simply describe the change, and not include any other information like predicted or known functional consequences.
 
 !!! note "I found a variant on DNA level which is a well-characterised splice variant. Is it correct to describe the variant as concluded from literature?"
 
-    No, you should report what **you** have found. You can however use the published data to give the predicted consequences on RNA/protein level, e.g. NM_004006.3:c.3430C>T r.(3277_3432del) p.(Leu1093_Gln1144del).
+    No, you should report what **you** have found. You can however use the published data to give the predicted consequences on RNA/protein level, e.g. `NM_004006.3:c.3430C>T` `r.(3277_3432del)` `p.(Leu1093_Gln1144del)`.


### PR DESCRIPTION
## Update the formatting of the RNA pages.
I found several issues during this reformatting.
To be decided:
- Should parts of variant descriptions, such as coordinate types, positions, bases or short sequences, and variant types ("del", "delins", etc) also be quoted?
- The original pages have a better markup; example, newline, more info, newline, possible NOTE. In our current rendering, this is all one long line. I find the original markup more readable, but I believe it requires `<br>` tags to achieve this in Markdown.

Still to do:
- The notes sometimes refer to the variables used in the syntax description. Because these may still change, I have not updated these. This still needs to be done.
- Given sequences that describe the context of a variant may sometimes need a legend. When I thought it would improve readability, I kept both sequences given ("before" and "after") and highlighted the sequence that would be deleted in the "before" sequence and the replaced sequence in the "after" sequence. For instance, on the RNA dup page, the last comment.

Nomenclature issues:
- The RNA insertion page contains faulty suggestions. Same for the RNA inversion page. I have not removed them, as we're currently unsure how to describe this. I did mark them as invalid.
- I find the last suggestion on the RNA delins page against the standards (splitting a variant up into two descriptions because one part is a common variant). But it's similar to the exception given on the delins page that is an exception to the exception as described on the RNA substitution page (two substitutions become one delins if they affect the same codon). This is confusing, and it would be good to straighten this out.

Technical issues:
- The indentation present in the original pages is often lost. Lists in lists are rendered as a single list. This may be an issue with our rendering because my Markdown preview works, but `mkdocs` doesn't render it well unless I increase the indentation of the sublist items in the source code. But I can't commit that, because the pre-commit hook keeps undoing my changes. See, for instance, the RNA delins examples. There seems to be one sublist, but there should be more.