### PR TITLE
restore text that was indvertently deleted from DNA/alleles

### DIFF
--- a/docs/recommendations/DNA/alleles.md
+++ b/docs/recommendations/DNA/alleles.md
@@ -12,9 +12,15 @@ bin/pull-syntax -f docs/syntax.yaml dna.alleles
 
 ## Notes
 
-- Do not assert reference agreement for in allele expressions. For example, <code class="invalid">LRG_199t1:c.[2376G>C;3103=];[2376=;3103del]</code> is invalid.
-- Alleles must use the same reference sequence types. For example, <code class="invalid"><code
-    class="spot1">c.</code>`[76A>C];`<code class="spot1">g.</code>`[10091C>G]`</code> is not permitted.
+- humans are diploid organisms and have **two alleles** at each genetic locus, with one allele inherited from each parent
+- when two variants are identified in a gene that are on **one chromosome** (in cis) this should be described as `g.[variant1`<code class="spot1">;</code>`variant2]`.
+- when two variants are identified in a gene that are **on different chromosomes** (in trans) this should be described as `g.[variant1]`<code class="spot1">;</code>`[variant2]`.
+- using allele descriptions involving two or more different variants you do not indicate the other allele does not contain the variant (unless one allele contains no variants at all). `LRG_199t1:c.[2376G>C];[3103del]` is correct, <code class="invalid">LRG_199t1:c.[2376G>C;3103=];[2376=;3103del]</code> is not correct.
+- when two variants are identified in a gene, but when it is **not known** whether these are on one chromosome (in cis) or on different chromosomes (in trans), this should be described as `variant1`<code class="spot1">(;)</code>`variant2`, i.e. without using `[ ]`.
+- NOTE: in the latest publication of the recommendations ([Den Dunnen et al. (2016)](http://onlinelibrary.wiley.com/doi/10.1002/humu.22981/pdf)) the example given is not correct.
+- NOTE: it is recommended to determine whether the changes are on the same chromosome or not.
+- descriptions combining variants based on different reference sequence types (e.g. <code class="spot1">c.</code>`[76A>C];`<code class="spot1">g.</code>`[10091C>G]`) should not be used.
+
 
 ## Examples
 

--- a/docs/recommendations/DNA/alleles.md
+++ b/docs/recommendations/DNA/alleles.md
@@ -19,7 +19,7 @@ bin/pull-syntax -f docs/syntax.yaml dna.alleles
 - when two variants are identified in a gene, but when it is **not known** whether these are on one chromosome (in cis) or on different chromosomes (in trans), this should be described as `variant1`<code class="spot1">(;)</code>`variant2`, i.e. without using `[ ]`.
 - NOTE: in the latest publication of the recommendations ([Den Dunnen et al. (2016)](http://onlinelibrary.wiley.com/doi/10.1002/humu.22981/pdf)) the example given is not correct.
 - NOTE: it is recommended to determine whether the changes are on the same chromosome or not.
-- descriptions combining variants based on different reference sequence types (e.g. <code class="spot1">c.</code>`[76A>C];`<code class="spot1">g.</code>`[10091C>G]`) should not be used.
+- descriptions combining variants based on different reference sequence types (e.g. <code class="invalid">c.[76A>C];g.[10091C>G]</code>) should not be used.
 
 
 ## Examples

--- a/docs/syntax.yaml
+++ b/docs/syntax.yaml
@@ -31,9 +31,9 @@ aa:
         examples:
           - NP_003997.1:p.[(Ser73Arg)];[(Asn103del)]
       - name: Variants with unknown or uncertain phase
-        syntax: sequence_identifier ":" coordinate_type "." "[" position_edit "(;)" position_edit "]"
+        syntax: sequence_identifier ":" coordinate_type "." position_edit "(;)" position_edit
         examples:
-          - NP_003997.1:p.[(Ser73Arg)](;)[(Asn103del)]
+          - NP_003997.1:p.(Ser73Arg)](;)[(Asn103del)
   del:
     elements:
     forms:
@@ -140,9 +140,9 @@ dna:
         examples:
           - NC_000001.11:g.[123G>A];[345del]
       - name: Variants with unknown or uncertain phase
-        syntax: sequence_identifier ":" coordinate_type "." "[" position_edit "(;)" position_edit "]"
+        syntax: sequence_identifier ":" coordinate_type "." position_edit "(;)" position_edit
         examples:
-          - NC_000001.11:g.[123G>A(;)345del]
+          - NC_000001.11:g.123G>A(;)345del
   del:
     elements:
     forms:
@@ -236,9 +236,9 @@ rna:
         examples:
           - NM_004006.3:r.[123c>a];[345del]
       - name: Variants with unknown or uncertain phase
-        syntax: sequence_identifier ":" coordinate_type "." "[" first_change "(;)" second_change "]"
+        syntax: sequence_identifier ":" coordinate_type "." first_change "(;)" second_change
         examples:
-          - NM_004006.3:r.[123c>a(;)345del]
+          - NM_004006.3:r.123c>a(;)345del
   del:
     elements:
       sequence_identifier: the sequence identifier used; NM_004006.3


### PR DESCRIPTION
Restore text that was inadvertently deleted from DNA/alleles. Also, fixes the syntax table and examples. 

@ifokkema @rileygr: This PR should address the text that was inadvertently removed from DNA/alleles. Does this solve the problem?