### PR TITLE
remove repo badges from software list

### DIFF
--- a/lib/templates/software-table.html.jinja2
+++ b/lib/templates/software-table.html.jinja2
@@ -14,12 +14,6 @@
 <br />{{md|markdown}}
 {% endfor %}
 {% endif %}
-<br />[![Issues](https://img.shields.io/github/issues-raw/{{repo_slug}}.svg)](https://github.com/{{repo_slug}}/issues)
-<br />[![Open Pull
-Requests](https://img.shields.io/github/issues-pr/{{repo_slug}}.svg)](https://github.com/{{repo_slug}}/pull/)
-<br />[![Contributors](https://img.shields.io/github/contributors/{{repo_slug}}.svg)](https://github.com/{{repo_slug}}/graphs/contributors/)
-<br />[![Stars](https://img.shields.io/github/stars/{{repo_slug}}.svg?style=social&label=Stars)](https://github.com/{{repo_slug}}/stargazers)
-<br />[![Forks](https://img.shields.io/github/forks/{{repo_slug}}.svg?style=social&label=Forks)](https://github.com/{{repo_slug}}/network)
 {% endmacro %}
 
 <table>


### PR DESCRIPTION
Based on discussion from today's HVNC meeting, I have removed most of the repo badges. The current page now looks like this:

![image](https://github.com/HGVSnomenclature/hgvs-nomenclature/assets/109453/da44a70d-bbe0-4b0a-a39c-b53dda692720)
