### PR TITLE
129 - Revise use of "fusion transcript" to "adjoined transcript" (attempt 2)

### DIFF
--- a/docs/background/versioning.md
+++ b/docs/background/versioning.md
@@ -17,7 +17,7 @@ The HGVS Nomenclature now uses concepts from [Semantic Versioning](https://semve
 - **Version 20.05**: Accepted proposals include [SVD-WG007](../consultation/SVD-WG007.md) and [SVD-WG008](../consultation/SVD-WG008.md):
 
     - SVD-WG008 (_Reference Sequences_): specifies requirements for acceptable Reference Sequences
-    - SVD-WG007 (_RNA fusion_): specifies how to describe RNA fusion transcripts
+    - SVD-WG007 (_RNA fusion_): specifies how to describe adjoined transcripts from gene fusions
 
 - **Version 19.01**: Accepted proposals include [SVD-WG005](../consultation/SVD-WG005.md) and [SVD-WG006](../consultation/SVD-WG006.md):
 

--- a/docs/consultation/SVD-WG007.md
+++ b/docs/consultation/SVD-WG007.md
@@ -14,11 +14,11 @@ The proposal suggests to extend the HGVS recommendations with a format to descri
 
 #### Examples
 
-- translocation-derived adjoined transcript: NM_152263.2:r.-115_775::NM_002609.3:r.1580\_\*1924: an adjoined transcript from a TPM3::PDGFRB gene fusion, where nucleotides r.-115 to r.775 (reference transcript NM_152263.2, TPM3 gene) are coupled to nucleotides r.1580 to r.\*1924 (reference transcript NM_002609.3, PDGFRB gene)
-- deletion-derived adjoined transcript: NM_002354.2:r.-358_555::NM_000251.2:r.212\_\*279: an adjoined transcript from an EPCAM::MSH2 gene fusion, where nucleotides r.-358 to r.555 (reference transcript NM_002354.2, EPCAM gene) are coupled to nucleotides r.212 to r.\*279 (reference transcript NM_000251.2, MSH2 gene)
+- translocation-derived adjoined transcript: `NM_152263.2:r.-115_775::NM_002609.3:r.1580_*1924`: an adjoined transcript from a `TPM3::PDGFRB` gene fusion, where nucleotides `r.-115` to `r.775` (reference transcript NM_152263.2, _TPM3_ gene) are coupled to nucleotides `r.1580` to `r.*1924` (reference transcript NM_002609.3, _PDGFRB_ gene)
+- deletion-derived adjoined transcript: `NM_002354.2:r.-358_555::NM_000251.2:r.212_*279`: an adjoined transcript from an `EPCAM::MSH2` gene fusion, where nucleotides `r.-358` to `r.555` (reference transcript NM_002354.2, _EPCAM_ gene) are coupled to nucleotides `r.212` to `r.*279` (reference transcript NM_000251.2, _MSH2_ gene)
 - NOTES
-    - ::aggcucccuugg::: a format like "**::aggcucccuugg::**" is used to indicate the insertion of a 12 nucleotide sequence (aggcucccuugg) between two adjoined transcripts
-    - NM_152263.2:r.?\_775::NM_002609.3:r.1580\_?: when only the sequence adjacency and not the entire transcript has been analysed, the format NM_152263.2:r.?\_775::NM_002609.3:r.1580\_? should be used
+    - `::aggcucccuugg::`: a format like **`::aggcucccuugg::`** is used to indicate the insertion of a 12 nucleotide sequence (`aggcucccuugg`) between two adjoined transcripts
+    - `NM_152263.2:r.?_775::NM_002609.3:r.1580_?`: when only the sequence adjacency and not the entire transcript has been analysed, the format `NM_152263.2:r.?_775::NM_002609.3:r.1580_?` should be used
 
 #### NOTE
 

--- a/docs/consultation/SVD-WG007.md
+++ b/docs/consultation/SVD-WG007.md
@@ -8,18 +8,18 @@
 
 Based on the proposal the [RNA Deletion-insertion page](../recommendations/RNA/delins.md) has been updated (April 2020).
 
-The proposal suggests to extend the HGVS recommendations with a format to decribe RNA fusion transcripts
+The proposal suggests to extend the HGVS recommendations with a format to decribe adjoined transcripts derived from gene fusions
 
-- RNA fusion transcripts are described following the format to describe a fusion between two DNA molecules (translocations), i.e. using **"::"**.
+- Adjoined transcripts are described following the format to describe a gene fusion between two DNA molecules (translocations), i.e. using **"::"**.
 
 #### Examples
 
-- translocation fusion: NM_152263.2:r.-115_775::NM_002609.3:r.1580\_\*1924: a TPM3::PDGFRB fusion transcript where nucleotides r.-115 to r.775 (reference transcript NM_152263.2, TPM3 gene) are coupled to nucleotides r.1580 to r.\*1924 (reference transcript NM_002609.3, PDGFRB gene)
-- deletion fusion: NM_002354.2:r.-358_555::NM_000251.2:r.212\_\*279: EPCAM::MSH2 fusion transcript where nucleotides r.-358 to r.555 (reference transcript NM_002354.2, EPCAM gene) are coupled to nucleotides r.212 to r.\*279 (reference transcript NM_000251.2, MSH2 gene)
+- translocation-derived adjoined transcript: NM_152263.2:r.-115_775::NM_002609.3:r.1580\_\*1924: an adjoined transcript from a TPM3::PDGFRB gene fusion, where nucleotides r.-115 to r.775 (reference transcript NM_152263.2, TPM3 gene) are coupled to nucleotides r.1580 to r.\*1924 (reference transcript NM_002609.3, PDGFRB gene)
+- deletion-derived adjoined transcript: NM_002354.2:r.-358_555::NM_000251.2:r.212\_\*279: an adjoined transcript from an EPCAM::MSH2 gene fusion, where nucleotides r.-358 to r.555 (reference transcript NM_002354.2, EPCAM gene) are coupled to nucleotides r.212 to r.\*279 (reference transcript NM_000251.2, MSH2 gene)
 - NOTES
-    - ::aggcucccuugg::: a format like "**::aggcucccuugg::**" is used to indicate the insertion of a 12 nucletoide sequence (aggcucccuugg) between two fusion transcripts
-    - NM_152263.2:r.?\_775::NM_002609.3:r.1580\_?: when only the break point and not the entire transcript has been analysed the format NM_152263.2:r.?\_775::NM_002609.3:r.1580\_? should be used
+    - ::aggcucccuugg::: a format like "**::aggcucccuugg::**" is used to indicate the insertion of a 12 nucleotide sequence (aggcucccuugg) between two adjoined transcripts
+    - NM_152263.2:r.?\_775::NM_002609.3:r.1580\_?: when only the sequence adjacency and not the entire transcript has been analysed, the format NM_152263.2:r.?\_775::NM_002609.3:r.1580\_? should be used
 
 #### NOTE
 
-All fusion transcripts are described using the same format irrepsective of whether they derive from inter-chromosomal or intra-chromosomal rearrangements (translocation, deletion, inversion).
+All adjoined transcripts are described using the same format irrespective of whether they derive from inter-chromosomal or intra-chromosomal DNA rearrangements (translocation, deletion, inversion) or other mechanisms (trans-splicing).

--- a/docs/consultation/SVD-WG007.md
+++ b/docs/consultation/SVD-WG007.md
@@ -8,7 +8,7 @@
 
 Based on the proposal the [RNA Deletion-insertion page](../recommendations/RNA/delins.md) has been updated (April 2020).
 
-The proposal suggests to extend the HGVS recommendations with a format to decribe adjoined transcripts derived from gene fusions
+The proposal suggests to extend the HGVS recommendations with a format to describe adjoined transcripts derived from gene fusions
 
 - Adjoined transcripts are described following the format to describe a gene fusion between two DNA molecules (translocations), i.e. using **"::"**.
 

--- a/docs/consultation/index.md
+++ b/docs/consultation/index.md
@@ -26,7 +26,7 @@ The HGVS Nomenclature is administed by the [HGVS Variant Nomenclature Committee 
 
 - [SVD-WG008](SVD-WG008.md) (Reference Sequences): suggested to specify the HGVS recommendations for acceptable Reference Sequences (see updated [Reference Sequences](../background/refseq.md) page): **Status**: <code class="spot1">accepted</code>. Closed Sep.30 (2019). Opened Jul.20 (2019).
 
-- [SVD-WG007](SVD-WG007.md) (RNA fusion): suggests to extend the HGVS recommendations with a format to describe RNA fusion transcripts following the format to describe a fusion between two DNA molecules (translocations), i.e. using "::": **Status**: <code class="spot1">accepted</code>. Closed Jun.30 (2019). Opened Apr.10 (2019).
+- [SVD-WG007](SVD-WG007.md) (RNA fusion): suggests to extend the HGVS recommendations with a format to describe adjoined transcripts from gene fusions, following the format to describe a fusion between two DNA molecules (translocations), i.e. using "::": **Status**: <code class="spot1">accepted</code>. Closed Jun.30 (2019). Opened Apr.10 (2019).
 
 - [SVD-WG006](SVD-WG006.md) (circular DNA): suggests to extend the HGVS recommendations allowing a **"o."** prefix for circular genomic reference sequences.: suggests to add the exception for circular genomic reference sequences ("m." and "o." prefix) to allow NC_012920.1:m.16563_13del: **Status**: <code class="spot1">accepted</code>. Closed Oct.30 (2018). Opened Aug.1 (2018).
 

--- a/docs/consultation/open-issues.md
+++ b/docs/consultation/open-issues.md
@@ -122,7 +122,7 @@ HGVS nomenclature does not give specific recommendations for the **numbering of 
 
 ### Imperfect copies
 
-**The proposal has been REJECTED** Accepting the proposal, without a whole range of specifications, would add **too many** options to decribe specific variants.
+**The proposal has been REJECTED** Accepting the proposal, without a whole range of specifications, would add **too many** options to describe specific variants.
 
 HGVS nomenclature has excellent possibilities to describe large duplications, inversions, conversions and insertions. However, no clear recommendations are available what to do when the nucleotides involved are not a perfect copy of the original sequence. The suggestion has been made ([Taschner PEM, Den Dunnen JT (2011). Hum.Mutat. 32:507-511](http://onlinelibrary.wiley.com/doi/10.1002/humu.21427/pdf)) to use "**{ }**" (curly braces) as a kind of "_sub-alleles_" to describe the variants in the altered region.
 

--- a/docs/recommendations/DNA/complex.md
+++ b/docs/recommendations/DNA/complex.md
@@ -21,7 +21,7 @@ The named ISCN extension has been introduced in 2016 and was modified last in Ma
             - **NOTE:** the description of the supernumerary molecule is given using "[ ]sup": **NOTE:** changed in ISCN2020. ISCN2016 had: _"add" for additional sequence_
         - `::` a double colon is used to designate break point junctions creating a ring chromosome.
                 - **NOTE:** "::" changed in ISCN2020. ISCN2016 had: _is used to designate break point junctions involving sequences from different chromosomes (translocation, transposition), chromothripsis break point junctions and junctions creating a ring chromosome_
-                - **NOTE:** `::` is also used to designate the junction of fusion transcripts
+                - **NOTE:** `::` is also used to designate adjoined transcripts
 - chromosomal banding patterns are translated to genomic coordinates based the translation tables provided by NCBI (see [Standards](../../background/standards.md#ISCN))
 - in ISCN it is allowed to describe nucleotide positions using commas to indicate thousands and millions (e.g. "108,111,982"), in HGVS this is not allowed.
 - 3'rule: to determine the location of the break point, the general HGVS rule of maintaining the longest unchanged sequence applies (the 3' rule). Break point location is determined by the first break point encountered, i.e. from pter of the chromosome to be listed first

--- a/docs/recommendations/RNA/delins.md
+++ b/docs/recommendations/RNA/delins.md
@@ -17,7 +17,7 @@ bin/pull-syntax -c -f docs/syntax.yaml rna.delins
 - two variants separated by one or more nucleotides should preferably be described individually and **not** as a "delins"
     - exception: two variants separated by one nucleotide, together affecting one amino acid, should be described as a "delins" (e.g. `r.142_144delinsugg` `p.(Arg48Trp)`). **NOTE:** this prevents tools predicting the consequences of a variant to make conflicting and incorrect predictions of two different substitutions at one position.
     - **conversions**, a sequence change where a range of nucleotides are replaced by a sequence from elsewhere in the genome, are described as a "delins". The previous format "con" is no longer used (see [Community Consultation SVD-WG009)](../../consultation/SVD-WG009.md)).
-- RNA-fusion transcripts represent a special case of deletion-insertion variant. The fusion break point is described using **"::"**. **NOTE:** to avoid confusion, HGVS recommends to follow the [HGNC guidelines](https://www.genenames.org/about/guidelines/) to describe products of gene translocations or fusions (format GENESYMBOL1::GENESYMBOL2) and readthrough transcripts (format GENESYMBOL1-GENESYMBOL2).
+- Adjoined transcripts from gene fusions represent a special case of deletion-insertion variant. The fusion break point is described using **"::"**. **NOTE:** to avoid confusion, HGVS recommends to follow the [HGNC guidelines](https://www.genenames.org/about/guidelines/) to describe products of gene translocations or fusions (format GENESYMBOL1::GENESYMBOL2) and readthrough transcripts (format GENESYMBOL1-GENESYMBOL2).
 - for all descriptions the **most 3' position** possible of the reference sequence is arbitrarily assigned to have been changed (**3'rule**)
 
 ## Examples
@@ -30,11 +30,11 @@ bin/pull-syntax -c -f docs/syntax.yaml rna.delins
     - `NM_004006.2:r.2623_2803delins2804_2949`: conversion replacing nucleotides r.2623 to r.2803 (exon 21) with nucleotides r.2804 to r.2949 (exon 22) as found in the DMD coding RNA sequence file NM_004006.2
     - `r.415_1655delins[AC096506.5:g.409_1649]`: conversion replacing nucleotides r.414 to r.1655 with nucleotides 409 to 1649 as found in the genomic reference sequence AC096506.5
     - `r.1401_1446delins[NR_002570.3:r.1513_1558]`: conversion in exon 9 of the CYP2D6 gene replacing exon 9 nucleotides r.1401 to r.1446 with those of the 3' flanking CYP2D7P1 gene, nucleotides r.1513 to r.1558
-- RNA fusion transcripts (based on [SVD-WG007](../../consultation/SVD-WG007.md))
-    - translocation fusion: `NM_152263.2:r.-115_775::NM_002609.3:r.1580_*1924` describes a TPM3::PDGFRB fusion transcript where nucleotides r.-115 to r.775 (reference transcript NM_152263.2, TPM3 gene) are coupled to nucleotides r.1580 to r.\*1924 (reference transcript NM_002609.3, PDGFRB gene)
-    - **deletion fusion**
-        - `NM_002354.2:r.-358_555::NM_000251.2:r.212_*279`: describes an EPCAM::MSH2 fusion transcript where nucleotides r.-358 to r.555 (reference transcript NM_002354.2, EPCAM gene) are coupled to nucleotides r.212 to r.\*279 (reference transcript NM_000251.2, MSH2 gene)
-        - `NM_002354.2:r.?_555::guaugauuuuuuaataa::NM_000251.2:r.212_?`: describes an EPCAM::MSH2 fusion transcript where only the fusion break point has been characterised, showing the insertion of a 17 nucletoide sequence (guaugauuuuuuaataa) between two fusion transcripts
+- Adjoined transcripts from gene fusions (based on [SVD-WG007](../../consultation/SVD-WG007.md))
+    - translocation-derived adjoined transcript: `NM_152263.2:r.-115_775::NM_002609.3:r.1580_*1924` describes an adjoined transcript from a TPM3::PDGFRB gene fusion, where nucleotides r.-115 to r.775 (reference transcript NM_152263.2, TPM3 gene) are coupled to nucleotides r.1580 to r.\*1924 (reference transcript NM_002609.3, PDGFRB gene)
+    - deletion-derived adjoined transcripts:
+        - `NM_002354.2:r.-358_555::NM_000251.2:r.212_*279`: describes an adjoined transcript from an EPCAM::MSH2 gene fusion, where nucleotides r.-358 to r.555 (reference transcript NM_002354.2, EPCAM gene) are coupled to nucleotides r.212 to r.\*279 (reference transcript NM_000251.2, MSH2 gene)
+        - `NM_002354.2:r.?_555::guaugauuuuuuaataa::NM_000251.2:r.212_?`: describes an adjoined transcript from an EPCAM::MSH2 gene fusion, where only the fusion break point has been characterised, showing the insertion of a 17 nucletoide sequence (guaugauuuuuuaataa) between two adjoined transcripts
 
 ## Discussion
 

--- a/docs/recommendations/RNA/splicing.md
+++ b/docs/recommendations/RNA/splicing.md
@@ -34,8 +34,8 @@ Variants affecting RNA splicing result in either a [deletion](deletion.md) or [i
     - `NC_000023.11(NM_004006.2):r.649_650ins650-50_650-1`: as a consequence of an intron 7 variant (c.650-52_650-51del) a new stronger exon 8 splice acceptor site is created (position 650-51 / 650-50) and the intron 7 sequence from positions 650-50 to 650-1 is inserted in the transcript: alternative description `LRG_199t1:r.649_650ins650-50_650-1`
     - `NC_000023.11(NM_004006.2):r.831_832ins831+1_831+67`: as a consequence of an intron 8 variant (c.831+71C>A) a new stronger exon 8 splice donor site is created (position 831+67 / 831+68) and the intron 8 sequence from positions 831+1 to 831+67 is inserted in the transcript: alternative description `LRG_199t1:r.831_832ins831+1_831+67`
     - `NC_000023.11(NM_004006.2):r.649_650ins650-1400_650-1268`: as a consequence of an intron 7 variant (c.650-1401T>G) a new exon is created and its sequence (positions 650-1400 to 650-1268) is inserted in the transcript: alternative description `LRG_199t1:r.649_650ins650-1400_650-1268`
-- **fusion transcript** (based on [SVD-WG007](../../consultation/SVD-WG007.md))
-    - `NM_002354.2:r.-358_555::NM_000251.2:r.212_*279`: describes an EPCAM::MSH2 fusion transcript where nucleotides `r.-358` to `r.555` (EPCAM gene, reference transcript `NM_002354.2) are spliced to nucleotides r.212` to `r.*279` (MSH2 gene, reference transcript NM_000251.2)
+- **adjoiend transcript** (based on [SVD-WG007](../../consultation/SVD-WG007.md))
+    - `NM_002354.2:r.-358_555::NM_000251.2:r.212_*279`: describes an adjoined transcript from the EPCAM::MSH2 gene fusion, where nucleotides `r.-358` to `r.555` (EPCAM gene, reference transcript `NM_002354.2) are spliced to nucleotides r.212` to `r.*279` (MSH2 gene, reference transcript NM_000251.2)
 - **uncertain** (RNA not analysed)
     - `NC_000023.11(NM_004006.2):r.(76a>c)`: RNA was not anaysed but a substitution of the "a" nucleotide at `r.76` by a "c" is predicted
     - `NC_000023.11(NM_004006.2):r.?`: an effect on the RNA level is expected but it is not possible to give a reliable prediction of the consequences (RNA not analysed)

--- a/docs/recommendations/RNA/splicing.md
+++ b/docs/recommendations/RNA/splicing.md
@@ -34,7 +34,7 @@ Variants affecting RNA splicing result in either a [deletion](deletion.md) or [i
     - `NC_000023.11(NM_004006.2):r.649_650ins650-50_650-1`: as a consequence of an intron 7 variant (c.650-52_650-51del) a new stronger exon 8 splice acceptor site is created (position 650-51 / 650-50) and the intron 7 sequence from positions 650-50 to 650-1 is inserted in the transcript: alternative description `LRG_199t1:r.649_650ins650-50_650-1`
     - `NC_000023.11(NM_004006.2):r.831_832ins831+1_831+67`: as a consequence of an intron 8 variant (c.831+71C>A) a new stronger exon 8 splice donor site is created (position 831+67 / 831+68) and the intron 8 sequence from positions 831+1 to 831+67 is inserted in the transcript: alternative description `LRG_199t1:r.831_832ins831+1_831+67`
     - `NC_000023.11(NM_004006.2):r.649_650ins650-1400_650-1268`: as a consequence of an intron 7 variant (c.650-1401T>G) a new exon is created and its sequence (positions 650-1400 to 650-1268) is inserted in the transcript: alternative description `LRG_199t1:r.649_650ins650-1400_650-1268`
-- **adjoiend transcript** (based on [SVD-WG007](../../consultation/SVD-WG007.md))
+- **adjoined transcript** (based on [SVD-WG007](../../consultation/SVD-WG007.md))
     - `NM_002354.2:r.-358_555::NM_000251.2:r.212_*279`: describes an adjoined transcript from the EPCAM::MSH2 gene fusion, where nucleotides `r.-358` to `r.555` (EPCAM gene, reference transcript `NM_002354.2) are spliced to nucleotides r.212` to `r.*279` (MSH2 gene, reference transcript NM_000251.2)
 - **uncertain** (RNA not analysed)
     - `NC_000023.11(NM_004006.2):r.(76a>c)`: RNA was not anaysed but a substitution of the "a" nucleotide at `r.76` by a "c" is predicted

--- a/docs/recommendations/general.md
+++ b/docs/recommendations/general.md
@@ -69,7 +69,7 @@ In HGVS nomenclature some **characters** have a **specific meaning**
     - `NC_000002.11:g.48031621_48031622ins[TAT;48026961_48027223;GGC]`
     - `NC_000002.11:g.47643464_47643465ins[NC_000022.10:35788169_35788352]`
 - `:` (colon) is used to separate the reference sequence file identifier (_accession.version_number_) from the actual description of a variant; `NC_000011.9:g.12345611G>A`
-- `:`: (double colon) is used to describe RNA fusion transcripts ([RNA Deletion-insertion](RNA/delins.md)) and to designate break point junctions creating a ring chromosome ([DNA Complex (HGVS/ISCN)](DNA/complex.md))
+- `:`: (double colon) is used to describe adjoined transcripts from gene fusions ([RNA Deletion-insertion](RNA/delins.md)) and to designate break point junctions creating a ring chromosome ([DNA Complex (HGVS/ISCN)](DNA/complex.md))
 - `( )` (parentheses) are used to indicate uncertainties and predicted consequences; `NC_000023.9:g.(123456_234567)_(345678_456789)del`, `p.(Ser123Arg)` **NOTE**: the range of the uncertainty should be described as precisely as possible (see [below](#uncertain1))
 - `?` (question mark) is used to indicate unknown positions (nucleotide or amino acid); `g.(?_234567)_(345678_?)del`
 - `^` (caret) is used as "or"; `c.(370A>C^372C>R)` as back translation of `p.Ser124Arg` (i.e. changing the AGC codon to CGC, AGG or AGA)


### PR DESCRIPTION
Another pass at #130. Diff appears correct this time.

Addresses #129, disambiguating between gene fusions, rearrangements, and adjoined transcripts.