### PR TITLE
fix: resolve link warnings

### DIFF
--- a/docs/hvnc.md
+++ b/docs/hvnc.md
@@ -2,7 +2,7 @@
 
 !!! note inline end "Join Us"
 
-    Please see the [Call for Members](../call-for-members/) if you are interested in
+    Please see the [Call for Members](call-for-members.md) if you are interested in
     joining the HVNC and contributing to the maintenance of the HGVS Nomenclature.
 
 The HGVS Variant Nomenclature Committee (HVNC) is authorised by the [Human Genome Organisation (HUGO)](https://www.hugo-international.org), a working group of the [HUGO Nomenclature Standards Committee](https://www.hugo-international.org/standards), with administrative support of the HUGO office. Activities of the HVNC follow the committee's Terms of Reference with new members being appointed every two years for a four-year term. HVNC members should together represent all interested communities, including gene/disease specific database curators, central repositories, clinical geneticists, commercial diagnostic laboratories, bioinformaticians, scientific journals, etc. The HVNC is the successor of the HGVS nomenclature Sequence Variant Description Working Group (SVD-WG), initiated by the [Human Variome Project](https://www.humanvariomeproject.org/sdp/wg04-sequence-variant-description-committee.html).

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ The HGVS Nomenclature is administered by the [HGVS Variant Nomenclature Committe
 
 !!! note "Join Us"
 
-    Please see the [Call for Members](call-for-members/) if you are interested in
+    Please see the [Call for Members](call-for-members.md) if you are interested in
     joining the HVNC and contributing to the maintenance of the HGVS Nomenclature.
 
 ## Contact Us


### PR DESCRIPTION
```
WARNING -  Doc file 'index.md' contains an unrecognized relative link 'call-for-members/', it was left as is. Did you mean 'call-for-members.md'?
WARNING -  Doc file 'hvnc.md' contains an unrecognized relative link '../call-for-members/', it was left as is. Did you mean 'call-for-members.md'?
```