### PR TITLE
Remove "indel" except for where it's made clear it shouldn't be used.

### DIFF
--- a/docs/background/simple.md
+++ b/docs/background/simple.md
@@ -80,7 +80,7 @@ All variants given are in the DMD gene and reported in relation to coding DNA re
     - c.4375_4385dup: the nucleotides from position c.4375 to c.4385 (CGATTATTCCA) are present twice (duplicated). Often reported as c.4375_4385dupCGATTATTCCA or c.4385_4386insCGATTATTCCA (not a correct HGVS description).
 - insertion: one or more letters in the DNA code are new (inserted). An insertion is indicated using **"ins"**.
     - c.4375_4376insACCT: the new sequence "ACCT" was found inserted between positions c.4375 and c.4376.
-- deletion/insertion (indel): one or more letters in the DNA code are missing and replaced by several new letters. A deletion/insertion is indicated using **"delins"**.
+- deletion/insertion (delins): one or more letters in the DNA code are missing and replaced by several new letters. A deletion/insertion is indicated using **"delins"**.
     - c.4375_4376delinsAGTT: the nucleotides from position c.4375 to c.4376 (CG) are missing (deleted) and replaced by the new sequence "AGTT". Also reported as c.4375_4376delCGinsAGTT.
 
 There are more variant types yet these occur less frequently. For details see [header "Recommendations"](http://varnomen.hgvs.org/recommendations).

--- a/docs/recommendations/DNA/delins.md
+++ b/docs/recommendations/DNA/delins.md
@@ -76,7 +76,7 @@ bin/pull-syntax -f docs/syntax.yaml dna.delins
 
     No, this is not allowed.
     By definition, a substitution changes **one** nucleotide into **one** other nucleotide (see [Substitution](substitution.md)).
-    The change `TGT`<code class="del">GC</code>`CA` to `TGT`<code class="ins">TG</code>`CA` should be described as `g.4_5delinsTG`, i.e. a deletion/insertion (indel).
+    The change `TGT`<code class="del">GC</code>`CA` to `TGT`<code class="ins">TG</code>`CA` should be described as `g.4_5delinsTG`, i.e. a deletion/insertion (delins).
 
 !!! note "Are there specific recommendations regarding the maximum number of unchanged nucleotides between two single nucleotide variants and whether the change is described as a "delins" or as two separate changes?"
 

--- a/docs/recommendations/DNA/substitution.md
+++ b/docs/recommendations/DNA/substitution.md
@@ -83,7 +83,7 @@ bin/pull-syntax -f docs/syntax.yaml dna.sub
 
     No, this is not allowed.
     By definition, a substitution changes **one** nucleotide into **one** other nucleotide.
-    The change `..GAA`<code class="sub">GC</code>`CAG..` to `..GAA`<code class="sub">TG</code>`CAG..` should be described as `NG_012232.1:g.12_13delinsTG`, i.e. a deletion/insertion (indel) (see [Deletion-Insertion](delins.md) and Description - Note).
+    The change `..GAA`<code class="sub">GC</code>`CAG..` to `..GAA`<code class="sub">TG</code>`CAG..` should be described as `NG_012232.1:g.12_13delinsTG`, i.e. a deletion/insertion (delins) (see [Deletion-Insertion](delins.md) and Description - Note).
     When phase information is not available, the variant should be described as `NG_012232.1:g.12G>T(;)13C>G` (see [Alleles](alleles.md)).
 
 !!! note "The _BRCA1_ coding DNA reference sequence `NM_007294.3` from position `c.2074` to `c.2080` is `..CAT`<code class="sub">G</code>`ACA..`. A variant frequently found in the population is `..CAT`<code class="sub">A</code>`ACA..` (`NM_007294.3:c.2077G>A`). In a patient I found the sequence `..CAT`<code class="sub">A</code><code class="ins">TA</code>`ACA..`. Can I describe this variant as <code class="invalid">NM_007294.3:c.[2077G>A;2077_2078insTA]</code>?"

--- a/docs/recommendations/RNA/delins.md
+++ b/docs/recommendations/RNA/delins.md
@@ -57,7 +57,7 @@ bin/pull-syntax -c -f docs/syntax.yaml rna.delins
 
 !!! note "Can I describe a "gc" to "ug" variant as a dinucleotide substitution (<code class="invalid">r.4gc>ug</code>)?"
 
-    No this is not allowed. By definition a substitution changes **one** nucleotide into **one** other nucleotide (see [Substitution](http://www.HGVS.org/varnomen/recommendations/RNA/variant/substitution/)). The change `augu`<code class="del">gc</code>`ca` to `augu`<code class="ins">ug</code>`ca` should be described as `r.5_6delinsug`, i.e. a deletion/insertion (indel).
+    No this is not allowed. By definition a substitution changes **one** nucleotide into **one** other nucleotide (see [Substitution](http://www.HGVS.org/varnomen/recommendations/RNA/variant/substitution/)). The change `augu`<code class="del">gc</code>`ca` to `augu`<code class="ins">ug</code>`ca` should be described as `r.5_6delinsug`, i.e. a deletion/insertion (delins).
 
 !!! note "The BRCA1 coding RNA reference sequence from position `r.2074` to `r.2080` is `caugaca`. A variant frequently found in the population is `cau`<code class="sub">a</code>`aca` (`r.2077g>a`). In a patient I found the sequence `cau`<code class="sub">a</code><code class="ins">ua</code>`aca`. Can I describe this variant as <code class="invalid">r.[2077g>a;2077_2078insua]</code>?"
 

--- a/docs/recommendations/RNA/inversion.md
+++ b/docs/recommendations/RNA/inversion.md
@@ -16,7 +16,7 @@ bin/pull-syntax -c -f docs/syntax.yaml rna.inv
 - by definition, the region inverted ("positions_inverted") contains **more than one nucleotide**. The description `r.234inv` is therefore not allowed; a one nucleotide inversion should be described as a [substitution](substitution.md)
 - for all descriptions the **most 3' position** possible of the reference sequence is arbitrarily assigned to have been changed (**3'rule**)
 - **inverted duplications** are described as an insertion using the format `r.234_235ins123_234inv`, not as <code class="invalid">r.123_456dupinv</code>
-- since exon splice signals will be inverted, large genomic inversions on the RNA level usually give [deletion](deletion.md) or [deletion-insertion (indel)](delins.md) variants
+- since exon splice signals will be inverted, large genomic inversions on the RNA level usually give [deletion](deletion.md) or [deletion-insertion (delins)](delins.md) variants
 - inversions are not used on protein level. Depending on the (predicted) consequences of an inversion on protein level, changes are usually described as either a **delins** or a **frameshift**.
 
 ## Examples

--- a/docs/recommendations/RNA/substitution.md
+++ b/docs/recommendations/RNA/substitution.md
@@ -13,7 +13,7 @@ bin/pull-syntax -c -f docs/syntax.yaml rna.sub
 ## Notes
 
 - all variants **should be** described at the DNA level, descriptions at the RNA and/or protein level may be given in addition
-- substitutions involving two or more consecutive nucleotides are described as deletion/insertions (indels) (see [Deletion/insertion (delins)](delins.md)).
+- substitutions involving two or more consecutive nucleotides are described as deletion/insertions (delins) (see [Deletion/insertion](delins.md)).
 - two substitutions separated by one or more nucleotides should be described individually and not as a "delins"
     - exception: two variants separated by one nucleotide, together affecting one amino acid, should be described as a "delins" (e.g. `r.142_144delinsugg` (`p.Arg48Trp`)).<br>
       **NOTE:** this prevents tools predicting the consequences of a variant to make conflicting and incorrect predictions of two different substitutions at one position

--- a/docs/recommendations/protein/delins.md
+++ b/docs/recommendations/protein/delins.md
@@ -48,4 +48,4 @@ bin/pull-syntax -c -f docs/syntax.yaml aa.delins
 
 !!! note "Can I describe a TrpSer to CysArg variant as a amino acid substitution (`p.TrpSer23CysArg`)?"
 
-    No, this is not allowed. By definition a substitution changes **one** amino acid into **one** other amino acid. The change TrpSer to CysArg should be described as `p.Trp23_Ser24delinsCysArg`, i.e. a deletion/insertion (indel) (see [Deletion-Insertion](delins.md)).
+    No, this is not allowed. By definition a substitution changes **one** amino acid into **one** other amino acid. The change TrpSer to CysArg should be described as `p.Trp23_Ser24delinsCysArg`, i.e. a deletion/insertion (delins) (see [Deletion-Insertion](delins.md)).

--- a/docs/recommendations/protein/substitution.md
+++ b/docs/recommendations/protein/substitution.md
@@ -61,7 +61,7 @@ bin/pull-syntax -c -f docs/syntax.yaml aa.sub
 
 !!! note "Can I describe a TrpVal to CysArg variant as a amino acid substitution (`p.TrpVal24CysArg`)?"
 
-    No, this is not allowed. By definition a substitution changes **one** amino acid into **one** other amino acid. The change TrpVal to CysArg should be described as `NP_003997.1:p.Trp24_Val25delinsCysArg`, i.e. a deletion/insertion (indel) (see [Deletion-Insertion](../DNA/delins.md)).
+    No, this is not allowed. By definition a substitution changes **one** amino acid into **one** other amino acid. The change TrpVal to CysArg should be described as `NP_003997.1:p.Trp24_Val25delinsCysArg`, i.e. a deletion/insertion (delins) (see [Deletion-Insertion](../DNA/delins.md)).
 
 !!! note "How should you describe an amino acid substitution to any other amino acid?"
 

--- a/docs/software/hgvs.yml
+++ b/docs/software/hgvs.yml
@@ -28,6 +28,6 @@ description: |
   high-throughput sequencing to clinical diagnostics. The hgvs package does not
   attempt to cover the full scope of HGVS recommendations.  A key feature of the
   hgvs package is the ability to correctly project variants in the presence of
-  genome-transcript alignment indels (see
+  genome-transcript alignment deletion/insertions (see
   [PubMed:30129167](https://pubmed.ncbi.nlm.nih.gov/30129167/)).
 pubmed_id: "30129167"


### PR DESCRIPTION
Replaced all mentions with "delins" except for in the hgvs package description; there, I changed the sentence to:

> A key feature of the hgvs package is the ability to correctly project variants in the presence of genome-transcript alignment **deletion/insertions** (...)

@Reece, please change it if you prefer other wording.

Merging into `134-fix-all-remaining-style-issues` to prevent lots of conflicts later, as that branch is changing all the lines that I'm editing now as well.

Closes #142.