### PR TITLE
Typo in Protein Duplication

### DIFF
--- a/docs/syntax.yaml
+++ b/docs/syntax.yaml
@@ -69,7 +69,7 @@ aa:
         examples:
           - NP_003997.2:p.Val7dup
       - name: position range
-        syntax: sequence_identifier ":" coordinate_type "." aa_position "_" aa_position "delins" sequence
+        syntax: sequence_identifier ":" coordinate_type "." aa_position "_" aa_position "dup" sequence
         examples:
           - NP_003997.2:p.Lys23_Val25dup
   ext:

--- a/docs/syntax.yaml
+++ b/docs/syntax.yaml
@@ -69,7 +69,7 @@ aa:
         examples:
           - NP_003997.2:p.Val7dup
       - name: position range
-        syntax: sequence_identifier ":" coordinate_type "." aa_position "_" aa_position "dup" sequence
+        syntax: sequence_identifier ":" coordinate_type "." aa_position "_" aa_position "dup"
         examples:
           - NP_003997.2:p.Lys23_Val25dup
   ext:


### PR DESCRIPTION
While reviewing the page for protein duplication, I think I noticed a typo, where the range syntax specifies you should use the `delins` slug instead of the `dup` slug and should include the `sequence`, even though the example has `dup` with no sequence. I just updated the `syntax.yaml` file to address this (not sure if that is the right solution, this is my first contribution).

The issue, as seen on the main site:
<img width="1350" alt="Screen Shot 2024-03-06 at 9 38 32 AM" src="https://github.com/HGVSnomenclature/hgvs-nomenclature/assets/3450485/b410d845-7ec0-4541-be83-419fee226c04">

Addressed running locally on my branch:
<img width="1350" alt="Screen Shot 2024-03-06 at 9 58 59 AM" src="https://github.com/HGVSnomenclature/hgvs-nomenclature/assets/3450485/dcca03ed-3876-42b8-83ab-427af0c3eaa8">

