### PR TITLE
close #157: tell users how to receive release announcements

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,17 +15,18 @@ The HGVS Nomenclature is administered by the [HGVS Variant Nomenclature Committe
 Users of HGVS Nomenclature are invited to contact us to ask questions or get involved with its development.
 
 * Join the [HGVS Nomenclature](https://groups.google.com/g/hgvs-nomenclature)
-  group and mailing list. This is the preferred forum for interacting with other
-  users and the maintainers of HGVS Nomenclature.
-* Messages sent to
-  [hgvs-nomenclature@googlegroups.com](mailto:hgvs-nomenclature@googlegroups.com)
-  will be distributed to members by email.  While you do not need to be a member
-  to send a message to the group, **you will not see a reply unless you join the
-  group or manually check the [HGVS
-  Nomenclature](https://groups.google.com/g/hgvs-nomenclature) conversation
-  archive**.
+  group and mailing list. This is the preferred forum for discussing HGVS
+  Nomenclature questions and issues, and for receiving announcements about new
+  releases.
+    * Messages sent to
+      [hgvs-nomenclature@googlegroups.com](mailto:hgvs-nomenclature@googlegroups.com)
+      will be distributed to members by email.
+    * You do not need to be a member to send a message to the group. **However,
+      you will not see a reply unless you join the group or manually check the
+      [HGVS Nomenclature](https://groups.google.com/g/hgvs-nomenclature)
+      conversation archive**.
 * See [Community Consultation](consultation/index.md) for proposals, including
-  how to submit a proposal.
+  how to submit a proposal for future versions of HGVS Nomenclature.
 
 ## Current Citation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,9 +15,9 @@ The HGVS Nomenclature is administered by the [HGVS Variant Nomenclature Committe
 Users of HGVS Nomenclature are invited to contact us to ask questions or get involved with its development.
 
 * Join the [HGVS Nomenclature](https://groups.google.com/g/hgvs-nomenclature)
-  group and mailing list. This is the preferred forum for discussing HGVS
-  Nomenclature questions and issues, and for receiving announcements about new
-  releases.
+  group and mailing list. This is the preferred forum for discussing questions
+  and issues regarding the HGVS Nomenclature, and for receiving announcements
+  about new releases.
     * Messages sent to
       [hgvs-nomenclature@googlegroups.com](mailto:hgvs-nomenclature@googlegroups.com)
       will be distributed to members by email.
@@ -26,7 +26,7 @@ Users of HGVS Nomenclature are invited to contact us to ask questions or get inv
       [HGVS Nomenclature](https://groups.google.com/g/hgvs-nomenclature)
       conversation archive**.
 * See [Community Consultation](consultation/index.md) for proposals, including
-  how to submit a proposal for future versions of HGVS Nomenclature.
+  how to submit a proposal for future versions of the HGVS Nomenclature.
 
 ## Current Citation
 

--- a/docs/versions/index.md
+++ b/docs/versions/index.md
@@ -4,8 +4,7 @@
 
     Read the [release notes for the current version](21.0.md).
 
-    If you want to receive announcements of updates to HGVS Nomenclature, join the
-    [HGVS Nomenclature](https://groups.google.com/g/hgvs-nomenclature) group and mailing list
+    If you want to receive announcements of updates to the HGVS Nomenclature, join the [HGVS Nomenclature](https://groups.google.com/g/hgvs-nomenclature) group and mailing list
 
 The primary mission of HGVS Nomenclature is to facilitate reliable communication of sequence variants, which requires that the HGVS Nomenclature is stable.
 Nonetheless, modifications will be required from time to time in order to address new scientific needs, resolve inconsistencies, or clarify conventions.

--- a/docs/versions/index.md
+++ b/docs/versions/index.md
@@ -4,7 +4,7 @@
 
     Read the [release notes for the current version](21.0.md).
 
-    If you want to receive announcements of updates to the HGVS Nomenclature, join the [HGVS Nomenclature](https://groups.google.com/g/hgvs-nomenclature) group and mailing list
+    If you want to receive announcements of updates to the HGVS Nomenclature, join the [HGVS Nomenclature](https://groups.google.com/g/hgvs-nomenclature) group and mailing list.
 
 The primary mission of HGVS Nomenclature is to facilitate reliable communication of sequence variants, which requires that the HGVS Nomenclature is stable.
 Nonetheless, modifications will be required from time to time in order to address new scientific needs, resolve inconsistencies, or clarify conventions.

--- a/docs/versions/index.md
+++ b/docs/versions/index.md
@@ -4,6 +4,9 @@
 
     Read the [release notes for the current version](21.0.md).
 
+    If you want to receive announcements of updates to HGVS Nomenclature, join the
+    [HGVS Nomenclature](https://groups.google.com/g/hgvs-nomenclature) group and mailing list
+
 The primary mission of HGVS Nomenclature is to facilitate reliable communication of sequence variants, which requires that the HGVS Nomenclature is stable.
 Nonetheless, modifications will be required from time to time in order to address new scientific needs, resolve inconsistencies, or clarify conventions.
 A key goal of the [HVNC](../hvnc.md) is to manage such changes in a way that balances the needs of progress and reliable data sharing, and to communicate the changes to the community clearly.


### PR DESCRIPTION
Two changes:

1. on top/home page, add sentence (and slightly reformat) section with email group:

![image](https://github.com/HGVSnomenclature/hgvs-nomenclature/assets/109453/658a8fb0-3e77-4b40-9c6c-3094fb9ef1ed)

2. add sentence to box on versions page:

![image](https://github.com/HGVSnomenclature/hgvs-nomenclature/assets/109453/86e29f88-c74b-487d-9b01-2adb2a69f575)
