### PR TITLE
Fix description for supernumerary chromosome

### DIFF
--- a/docs/recommendations/DNA/complex.md
+++ b/docs/recommendations/DNA/complex.md
@@ -32,7 +32,6 @@ The named ISCN extension has been introduced in 2016 and was modified last in Ma
 
     - **`sup`**<br>
       the presence of an additional sequence which is not attached to other chromosomal material (i.e. trisomy, marker or ring chromosome) is indicated by `sup` (supernumerary chromosome).<br>
-      **NOTE**: the description of the supernumerary molecule is given using "[ ]sup".<br>
       **NOTE**: changed in ISCN2020.
       ISCN2016 had: _"add" for additional sequence_.
 

--- a/docs/recommendations/DNA/duplication.md
+++ b/docs/recommendations/DNA/duplication.md
@@ -117,7 +117,7 @@ bin/pull-syntax -f docs/syntax.yaml dna.dup
 
 - chromosome
     - **`NC_000023.11:g.pter_qtersup`**<br>
-      a duplication of the entire X-chromosome ("sup" = [supernumary chromosome](complex.md)).<br>
+      a duplication of the entire X-chromosome ("sup" = [supernumerary chromosome](complex.md)).<br>
       **NOTE**: when, e.g., based on next-generation sequencing, only "an additional copy of all X-chromosome sequences" is detected, the variant should be described as `NC_000023.11:g.pter_qter[2]`.
 - other
     - **`NC_000023.11:g.33344590_33344592=/dup`**<br>

--- a/docs/recommendations/general.md
+++ b/docs/recommendations/general.md
@@ -115,7 +115,7 @@ Specific abbreviations are used to describe different variant types.
     - `chr` indicates a **chromosome**; `chr11:g.12345611G>A` (`NC_000011.9`).
     - `pter` indicates the **first nucleotide** of a chromosome.
     - `qter` indicates the **last nucleotide** of a chromosome.
-    - `sup` indicates a **supernumary** chromosome (marker chromosome).
+    - `sup` indicates a **supernumerary** chromosome (marker chromosome).
 
 - changes of state (modifications):
     - `gom` indicates a **gain of methylation**; `g.12345678_12345901`<code class="spot1">|gom</code>.


### PR DESCRIPTION
### Fix the description for a supernumerary chromosome
- Fix the suggestion of using `[ ]sup` which should be `sup`. Removed the whole line since it added nothing to the already existing paragraph.
- Fix the naming as well; supernumary should be supernumerary.

Closes #153.