### PR TITLE
Remove call for members.

### DIFF
--- a/docs/call-for-members.md
+++ b/docs/call-for-members.md
@@ -1,5 +1,12 @@
 # Call for Members
 
+!!! warning "Expired"
+
+    This Call for Members has expired.
+    If you are interested in joining the HVNC in the future,
+     become a member of our [HGVS Nomenclature group](https://groups.google.com/g/hgvs-nomenclature)
+     to be notified of our next Call for Members.
+
 **Application due date: April 1, 2024**
 
 The HGVS Variant Nomenclature Committee (HVNC), one of HUGO's Nomenclature

--- a/docs/hvnc.md
+++ b/docs/hvnc.md
@@ -1,9 +1,9 @@
 # HGVS Variant Nomenclature Committee (HVNC)
 
-!!! note inline end "Join Us"
-
-    If you are interested in joining the HVNC and contributing to the maintenance of the HGVS Nomenclature, please see the [Call for Members](call-for-members.md).
-    **Applications are due April 1, 2024.**
+[//]: # (!!! note inline end "Join Us")
+[//]: # ()
+[//]: # (    If you are interested in joining the HVNC and contributing to the maintenance of the HGVS Nomenclature, please see the [Call for Members]&#40;call-for-members.md&#41;.)
+[//]: # (    **Applications are due April 1, 2024.**)
 
 The HGVS Variant Nomenclature Committee (HVNC) is authorised by the [Human Genome Organisation (HUGO)](https://www.hugo-international.org), a working group of the [HUGO Nomenclature Standards Committee](https://www.hugo-international.org/standards), with administrative support of the HUGO office.
 Activities of the HVNC follow the committee's Terms of Reference with new members being appointed every two years for a four-year term.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,10 +5,10 @@ It is used to convey variants in clinical reports and to share variants in publi
 
 The HGVS Nomenclature is administered by the [HGVS Variant Nomenclature Committee (HVNC)](hvnc.md) under the auspices of the [Human Genome Organization (HUGO)](https://hugo-int.org/).
 
-!!! note "Join Us"
-
-    If you are interested in joining the HVNC and contributing to the maintenance of the HGVS Nomenclature, please see the [Call for Members](call-for-members.md).
-    Applications are due **April 1, 2024**.
+[//]: # (!!! note "Join Us")
+[//]: # ()
+[//]: # (    If you are interested in joining the HVNC and contributing to the maintenance of the HGVS Nomenclature, please see the [Call for Members]&#40;call-for-members.md&#41;.)
+[//]: # (    Applications are due **April 1, 2024**.)
 
 ## Contact Us
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,8 +84,8 @@ theme:
   logo: images/hgvs-logo.png
   favicon: images/hgvs-logo.png
 
-# exclude_docs: |
-#   test/*
+exclude_docs: |
+  /call-for-members.md
 
 watch:
 - bin


### PR DESCRIPTION
### Remove call for members.
- Remove all references to the Call for Members page. I decided to keep all the references as Markdown comments. That way, we can easily put them back whenever we have a new call.
- Add an expiration notice on the call page in case people reach it. Whether it will be built depends on how `mkdocs` is invoked, and in case we'll still have it online and people reach it through Google or so, they'll know it's expired and how to watch for new calls.