### PR TITLE
remove commented call for members 

### DIFF
--- a/docs/hvnc.md
+++ b/docs/hvnc.md
@@ -1,10 +1,5 @@
 # HGVS Variant Nomenclature Committee (HVNC)
 
-[//]: # (!!! note inline end "Join Us")
-[//]: # ()
-[//]: # (    If you are interested in joining the HVNC and contributing to the maintenance of the HGVS Nomenclature, please see the [Call for Members]&#40;call-for-members.md&#41;.)
-[//]: # (    **Applications are due April 1, 2024.**)
-
 The HGVS Variant Nomenclature Committee (HVNC) is authorised by the [Human Genome Organisation (HUGO)](https://www.hugo-international.org), a working group of the [HUGO Nomenclature Standards Committee](https://www.hugo-international.org/standards), with administrative support of the HUGO office.
 Activities of the HVNC follow the committee's Terms of Reference with new members being appointed every two years for a four-year term.
 HVNC members should together represent all interested communities, including gene/disease specific database curators, central repositories, clinical geneticists, commercial diagnostic laboratories, bioinformaticians, scientific journals, etc.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,11 +5,6 @@ It is used to convey variants in clinical reports and to share variants in publi
 
 The HGVS Nomenclature is administered by the [HGVS Variant Nomenclature Committee (HVNC)](hvnc.md) under the auspices of the [Human Genome Organization (HUGO)](https://hugo-int.org/).
 
-[//]: # (!!! note "Join Us")
-[//]: # ()
-[//]: # (    If you are interested in joining the HVNC and contributing to the maintenance of the HGVS Nomenclature, please see the [Call for Members]&#40;call-for-members.md&#41;.)
-[//]: # (    Applications are due **April 1, 2024**.)
-
 ## Contact Us
 
 Users of HGVS Nomenclature are invited to contact us to ask questions or get involved with its development.


### PR DESCRIPTION
#166 commented out the call for new members. However, Read The Docs appear to not honor the comment notation and the call for new members remains (see https://hgvs-nomenclature.org/stable/). This PR removes the call entirely. (But it was a good idea, @ifokkema!).