### PR TITLE
2024-10-07 meeting updates

### DIFF
--- a/docs/background/numbering.md
+++ b/docs/background/numbering.md
@@ -41,7 +41,7 @@ nucleotide numbering is based on the annotated protein isoform, the major transl
       Correct descriptions refer to a genomic reference sequence like `LRG_199t1:c.357+1G>A`, `NC_000023.10(NM_004006.2):c.357+1G>A`, or `NG_012232.1(NM_004006.2):c.357+1G>A`.
 
 - **transcript flanking**<br>
-  it is **not** allowed to describe variants in nucleotides beyond the boundaries of a reference sequence, using that reference sequence.
+  it is **not** allowed to describe variants in nucleotides beyond the boundaries of a transcript reference sequence, using that transcript reference sequence.
     - suggestions made to extend the recommendations for nucleotide numbering of coding DNA reference sequences to specifically mark non-transcribed nucleotides have been made but were rejected (see [Open Issues](../consultation/open-issues.md)).
 
 Initial recommendations ([Antonarakis (1998)](http://onlinelibrary.wiley.com/doi/10.1002/%28SICI%291098-1004%281998%2911:1%3C1::AID-HUMU1%3E3.0.CO;2-O/pdf) and [Den Dunnen & Antonarakis (2000)](http://onlinelibrary.wiley.com/doi/10.1002/%28SICI%291098-1004%28200001%2915:1%3C7::AID-HUMU4%3E3.0.CO;2-N/pdf)) suggested two alternative descriptions for intronic variants; `c.88+2T>G` / `c.89-1G>T`, and `c.IVS2+2T>G` / `c.IVS2-1G>T`.
@@ -51,7 +51,7 @@ The latter format, `c.IVS2+2T>G` / `c.IVS2-1G>T`, has been retracted and **shoul
 
 - nucleotide numbering is `n.1`, `n.2`, `n.3`, ..., etc., from the first to the last nucleotide of the reference sequence.
 - nucleotides in introns are numbered as for coding DNA reference sequences [(see above)](#DNAc), although proceeded by `n.` (not `c.`).
-- it is **not** allowed to describe variants in nucleotides beyond the boundaries of a reference sequence, using that reference sequence.
+- it is **not** allowed to describe variants in nucleotides beyond the boundaries of a transcript reference sequence, using that transcript reference sequence.
 
 ### RNA reference sequences
 

--- a/docs/recommendations/DNA/substitution.md
+++ b/docs/recommendations/DNA/substitution.md
@@ -74,7 +74,7 @@ bin/pull-syntax -f docs/syntax.yaml dna.sub
     Describing the variant in relation to a coding DNA reference sequence is only possible when the nucleotide is included in this transcript reference sequence, or when a genomic sequence context is added.
     E.g., <code class="invalid">NM_004006.1:c.-128354C>T</code> or <code class="invalid">NM_000109.3:c.-401C>T</code> are invalid, because the positions `c.-128354` and `c.-401` are not included in the transcript reference sequences used.
     However, when adding in the context of a genomic reference sequence, this variant can be described as `NC_000023.10(NM_004006.1):c.-128354C>T` or `NC_000023.10(NM_000109.3):c.-401C>T`.
-    The variant can also be described using a genomic reference sequence containing the promoter region (for this variant e.g., `L01538.1:g.1407C>T`), but again this is not really informative.
+    The variant can also be described using a genomic reference sequence containing the promoter region (for this variant e.g., `L01538.1:g.1407C>T`).
     Although `NC_000023.10:g.33357783G>A` seems complex, it can be used in a genome browsers helping you to quickly zoom in on the region of interest.
 
 <a id="polymorphism"></a>

--- a/docs/recommendations/DNA/substitution.md
+++ b/docs/recommendations/DNA/substitution.md
@@ -70,8 +70,14 @@ bin/pull-syntax -f docs/syntax.yaml dna.sub
 
 !!! note "How should I describe a variant in the promoter region of a gene?"
 
-    It is recommended to describe variants in the promoter region of a gene based on a genomic reference sequence, e.g., `NC_000023.10:g.33357783G>A` (chrX, hg19). Describing the variant in relation to a coding DNA reference sequence (for this variant `NM_004006.1:c.-128354C>T` or `NM_000109.3:c.-401C>T` is possible but not really very informative; you do not know how long the 5'UTR is. The variant can also be described using a genomic reference sequence containing the promoter region (for this variant e.g., `L01538.1:g.1407C>T`), but again this is not really informative. Although `NC_000023.10:g.33357783G>A` seems complex, it can be used in a genome browsers helping you to quickly zoom in on the region of interest.<a id="polymorphism"></a>
+    It is recommended to describe variants in the promoter region of a gene based on a genomic reference sequence, e.g., `NC_000023.10:g.33357783G>A` (chrX, hg19).
+    Describing the variant in relation to a coding DNA reference sequence is only possible when the nucleotide is included in this transcript reference sequence, or when a genomic sequence context is added.
+    E.g., <code class="invalid">NM_004006.1:c.-128354C>T</code> or <code class="invalid">NM_000109.3:c.-401C>T</code> are invalid, because the positions `c.-128354` and `c.-401` are not included in the transcript reference sequences used.
+    However, when adding in the context of a genomic reference sequence, this variant can be described as `NC_000023.10(NM_004006.1):c.-128354C>T` or `NC_000023.10(NM_000109.3):c.-401C>T`.
+    The variant can also be described using a genomic reference sequence containing the promoter region (for this variant e.g., `L01538.1:g.1407C>T`), but again this is not really informative.
+    Although `NC_000023.10:g.33357783G>A` seems complex, it can be used in a genome browsers helping you to quickly zoom in on the region of interest.
 
+<a id="polymorphism"></a>
 !!! note "Are polymorphisms described like <code class="invalid">NM_004006.1:c.76A/G</code>?"
 
     No, all substitutions are described as `NM_004006.1:c.76A>G`.


### PR DESCRIPTION
### 2024-10-07 meeting updates
- Update the numbering page as discussed during today's meeting.
- Fixed error in an answer on the DNA substitution page. This was discussed in today's meeting. Using c. positions beyond the boundaries of the transcript reference sequence is not allowed when using only that transcript reference sequence, even though it's mentioned as a possibility in this answer. That is an error. However, today, we voted to allow using the c. coordinate system for intergenic positions as long as a genomic context was added. The answer has been corrected, and this new decision has been clarified.