### PR TITLE
Highlight negative examples as such.

### DIFF
--- a/docs/background/numbering.md
+++ b/docs/background/numbering.md
@@ -44,8 +44,8 @@ nucleotide numbering is based on the annotated protein isoform, the major transl
   it is **not** allowed to describe variants in nucleotides beyond the boundaries of a transcript reference sequence, using that transcript reference sequence.
     - suggestions made to extend the recommendations for nucleotide numbering of coding DNA reference sequences to specifically mark non-transcribed nucleotides have been made but were rejected (see [Open Issues](../consultation/open-issues.md)).
 
-Initial recommendations ([Antonarakis (1998)](http://onlinelibrary.wiley.com/doi/10.1002/%28SICI%291098-1004%281998%2911:1%3C1::AID-HUMU1%3E3.0.CO;2-O/pdf) and [Den Dunnen & Antonarakis (2000)](http://onlinelibrary.wiley.com/doi/10.1002/%28SICI%291098-1004%28200001%2915:1%3C7::AID-HUMU4%3E3.0.CO;2-N/pdf)) suggested two alternative descriptions for intronic variants; `c.88+2T>G` / `c.89-1G>T`, and `c.IVS2+2T>G` / `c.IVS2-1G>T`.
-The latter format, `c.IVS2+2T>G` / `c.IVS2-1G>T`, has been retracted and **should not be used**.
+Initial recommendations ([Antonarakis (1998)](http://onlinelibrary.wiley.com/doi/10.1002/%28SICI%291098-1004%281998%2911:1%3C1::AID-HUMU1%3E3.0.CO;2-O/pdf) and [Den Dunnen & Antonarakis (2000)](http://onlinelibrary.wiley.com/doi/10.1002/%28SICI%291098-1004%28200001%2915:1%3C7::AID-HUMU4%3E3.0.CO;2-N/pdf)) suggested two alternative descriptions for intronic variants; `c.88+2T>G` / `c.89-1G>T`, and <code class="invalid">c.IVS2+2T>G</code> / <code class="invalid">c.IVS2-1G>T</code>.
+The latter format, <code class="invalid">c.IVS2+2T>G</code> / <code class="invalid">c.IVS2-1G>T</code>, has been retracted and **should not be used**.
 
 ### non-coding DNA reference sequences
 

--- a/docs/background/simple.md
+++ b/docs/background/simple.md
@@ -134,14 +134,14 @@ All variants given are in the _DMD_ gene and reported in relation to coding DNA 
   A deletion is indicated using **"del"**.
     - **`c.4375_4379del`**<br>
       the nucleotides from position `c.4375` to `c.4379` (`CGATT`) are missing (deleted).
-      Sometimes misreported as `c.4375_4379delCGATT`.
+      Sometimes misreported as <code class="invalid">c.4375_4379delCGATT</code>.
 
 - **duplication**<br>
   one or more letters of the DNA code are present twice (doubled, duplicated).
   A duplication is indicated using **"dup"**.
     - **`c.4375_4385dup`**<br>
       the nucleotides from position `c.4375` to `c.4385` (`CGATTATTCCA`) are present twice (duplicated).
-      Sometimes misreported as `c.4375_4385dupCGATTATTCCA` or `c.4385_4386insCGATTATTCCA` (not a correct HGVS description).
+      Sometimes misreported as <code class="invalid">c.4375_4385dupCGATTATTCCA</code> or <code class="invalid">c.4385_4386insCGATTATTCCA</code>.
 
 - **insertion**<br>
   one or more letters in the DNA code are new (inserted).
@@ -154,7 +154,7 @@ All variants given are in the _DMD_ gene and reported in relation to coding DNA 
   A deletion/insertion is indicated using **"delins"**.
     - **`c.4375_4376delinsAGTT`**<br>
       the nucleotides from position `c.4375` to `c.4376` (`CG`) are missing (deleted) and replaced by the new sequence, `AGTT`.
-      Sometimes misreported as `c.4375_4376delCGinsAGTT`.
+      Sometimes misreported as <code class="invalid">c.4375_4376delCGinsAGTT</code>.
 
 There are more variant types, yet these occur less frequently.
 

--- a/docs/consultation/SVD-WG001.md
+++ b/docs/consultation/SVD-WG001.md
@@ -2,7 +2,7 @@
 
 ### NOTE
 
-In the [original proposal](http://www.hgvs.org/mutnomen/comments001.html), the descriptions included the nucleotide (`A`, `C`, `G`, or `T`) that was identified as not changed (`g.50377648A=`, `c.1823A=`, `n.611T=`).
+In the [original proposal](http://www.hgvs.org/mutnomen/comments001.html), the descriptions included the nucleotide (`A`, `C`, `G`, or `T`) that was identified as not changed (<code class="invalid">g.50377648A=</code>, <code class="invalid">c.1823A=</code>, <code class="invalid">n.611T=</code>).
 It should be noted that, following existing HGVS nomenclature (e.g., `g.123456del`, `c.123dup`) this addition is **not necessary**; `g.50377648=`, `c.1823=`, and `n.611=` are correct and preferred HGVS descriptions.
 
 ### Proposal SVD-WG001 (no change)

--- a/docs/recommendations/DNA/alleles.md
+++ b/docs/recommendations/DNA/alleles.md
@@ -96,7 +96,7 @@ bin/pull-syntax -f docs/syntax.yaml dna.alleles
     - disease severity will depend on the combination of variants found;
     - in recessive disease, when two variants are on one allele, an individual is a carrier or you might not have found the variant on the second allele.
 
-!!! note "I find the notation `c.[76A>C]` without describing the second allele misleading; not enough researchers know this refers to only one of the two alleles present. Would using <code class="invalid">c.[76A>C];[]</code> be OK?"
+!!! note "I find the notation <code class="invalid">c.[76A>C]</code> without describing the second allele misleading; not enough researchers know this refers to only one of the two alleles present. Would using <code class="invalid">c.[76A>C];[]</code> be OK?"
 
     No, the recommended description is `LRG_199t1:c.[76A>C];[76=]`, i.e. `c.76=` for "no change" at position `c.76` on the second allele.
 

--- a/docs/recommendations/RNA/alleles.md
+++ b/docs/recommendations/RNA/alleles.md
@@ -75,7 +75,7 @@ For more examples, see [DNA alleles](../DNA/alleles.md).
     - disease severity will depend on the combination of variants found;
     - in recessive disease, when two variants are in one transcript, an individual is a carrier or you might not have found the variant on transcripts from the second allele.
 
-!!! note "I find the notation `r.[76a>c]` without describing the second transcript allele misleading; not enough researchers know this refers to only one of the two transcripts present. Would using <code class="invalid">r.[76a>c];[]</code> be OK?"
+!!! note "I find the notation <code class="invalid">r.[76a>c]</code> without describing the second transcript allele misleading; not enough researchers know this refers to only one of the two transcripts present. Would using <code class="invalid">r.[76a>c];[]</code> be OK?"
 
     No, the recommended description is `r.76[a>c];[=]`, i.e. `r.76=` for "no change" at position `r.76` on the second transcript.
 


### PR DESCRIPTION
The HGVS nomenclature website uses negative examples to show what not to do. These examples are almost always labeled as invalid, so they are rendered in red, indicating visually to the reader that these variant descriptions are invalid.

A [recent analysis](https://github.com/HGVSnomenclature/hgvs-nomenclature/discussions/212) showed 89 invalid DNA descriptions on the HGVS website that were not labeled as invalid. This fixes those descriptions that are (IMO) clearly invalid examples, by labeling them as invalid examples. The descriptions themselves are not edited.