### PR TITLE
Fix several typos on the website and in examples

### DIFF
--- a/docs/recommendations/DNA/complex.md
+++ b/docs/recommendations/DNA/complex.md
@@ -135,7 +135,7 @@ HGVS, therefore, recommends to describe translocations exclusively using a "deli
           for ISCN `dup(8)(q24.21q24.22)`<br>
           _(within a chromosome, breakpoint not sequenced)_
 
-        - **`NC_000008.11:g.(131500001_136400000)ins[(127300001_131500000)_(131500001_136400000)inv]`**<br>
+        - **`NC_000008.11:g.(131500001_136400000)ins(127300001_131500000)_(131500001_136400000)inv`**<br>
           for ISCN `dup(8)(q24.22q24.21)`<br>
           _(within a chromosome, orientation reversed relative to original sequence, breakpoint not sequenced)_
 

--- a/docs/recommendations/DNA/deletion.md
+++ b/docs/recommendations/DNA/deletion.md
@@ -21,7 +21,7 @@ bin/pull-syntax -f docs/syntax.yaml dna.del
 - for all descriptions, the **most 3' position** possible of the reference sequence is arbitrarily assigned to have been changed (**3'rule**).
     - **exception**: deletions around exon/exon junctions when identical nucleotides flank the junction (see [Numbering](../../background/numbering.md#DNAc));<br>
       when `..GA`<code class="del">T</code>`gta..//..cagTCA..` changes to `..GAgta..//..cagTCA..`, based on a coding DNA reference sequence, the variant is described as `LRG_199t1:c.3921del` (`NC_000023.10:g.32459297del`) and not as `c.3922del` (which would translate to `g.32456507del`).
-- † = see [Uncertain](../uncertain.md); when the position and/or the sequence of a deletion has not been defined, a description may have a format like `g.(100_150)del(15)`.
+- † = see [Uncertain](../uncertain.md); when the position and/or the sequence of a deletion has not been defined, a description may have a format like `g.(100_150)delN[15]`.
 
 ## Examples
 

--- a/docs/recommendations/DNA/duplication.md
+++ b/docs/recommendations/DNA/duplication.md
@@ -89,8 +89,8 @@ bin/pull-syntax -f docs/syntax.yaml dna.dup
       **NOTE**: previously, the suggestion was made to describe such duplications using the format `c.4072-?_5154+?dup`.
       However, since `c.4072-?` indicates "**to an unknown position 5' of `c.4072`**" and `c.5154+?` "**to an unknown position 3' of `c.5154`**", this description is not correct when it is known that exons 29 and 37 are not involved.
 
-    - **`NC_000001.11(NM_206933.2):c.[675-542_1211-703dup;1211-703_1211-704insGTAAA]`**<br>
-      a duplication of the sequence from nucleotide position `c.75-542` to `c.1211-703`, followed by the insertion of the sequence <code class="ins">GTAAA</code>.<br>
+    - **`NC_000001.11(NM_206933.2):c.[675-542_1211-703dup;1211-703_1211-702insGTAAA]`**<br>
+      a duplication of the sequence from nucleotide position `c.675-542` to `c.1211-703`, followed by the insertion of the sequence <code class="ins">GTAAA</code>.<br>
       **NOTE**: the variant is not described using <code class="invalid">dupins</code>, a format not used in HGVS nomenclature.
 
     - **`NC_000023.11:g.(32381076_32382698)_(32430031_32456357)[3]` (`NC_000023.11(NM_004006.2):c.(4071+1_4072-1)_(5154+1_5155-1)[3]`)**<br>

--- a/docs/recommendations/DNA/repeated.md
+++ b/docs/recommendations/DNA/repeated.md
@@ -68,7 +68,7 @@ bin/pull-syntax -f docs/syntax.yaml dna.rpt
             - **`NM_002024.5:c.(-144_-16)insN[(1800_2400)]`**<br>
               the amplified region containing the _FMR1_ repeat region (between nucleotides `c.-144` and `c.-16`) contains an insertion of 1800 to 2400 nucleotides (600 to 800 `GGC` / `GGA` units).
 
-        - **_HTT_ repeat** (reference sequence `LRG_763t1:52_153CAG[21]CAA[1]CAG[1]CCG[1]CCA[1]CCG[7]CCT[2]`)<br>
+        - **_HTT_ repeat** (reference sequence `LRG_763t1:c.52_153CAG[21]CAA[1]CAG[1]CCG[1]CCA[1]CCG[7]CCT[2]`)<br>
           in literature, the Huntington's Disease tri-nucleotide repeat, encoding a variable poly-Gln followed by a variable poly-Pro repeat on protein level, is known as the `CAG` repeat.
           Based on the _HTT_ (huntingtin) coding DNA reference sequence (GenBank `LRG_763t1` or `NM_002111.8`) and applying the **3'rule**, the Poly-Gln encoding repeat has to be described as an `AGC`-`AAC`-`AGC` repeat.
             - **`LRG_763t1:c.54_110GCA[23]`**<br>

--- a/docs/recommendations/general.md
+++ b/docs/recommendations/general.md
@@ -80,7 +80,7 @@ In HGVS nomenclature, some **characters** have a **specific meaning**:
     - `;` (semicolon) is used to separate variants and alleles; `g.[123456A>G;345678G>C]` or `g.[123456A>G];[345678G>C]`.
     - `,` (comma) is used to separate different transcripts/proteins derived from one allele; `r.[123a>u,122_154del]`.
     - `NC_000002.11:g.48031621_48031622ins[TAT;48026961_48027223;GGC]`.
-    - `NC_000002.11:g.47643464_47643465ins[NC_000022.10:35788169_35788352]`.
+    - `NC_000002.11:g.47643464_47643465ins[NC_000022.10:g.35788169_35788352]`.
 - `:` (colon) is used to separate the reference sequence file identifier (_accession.version_number_) from the actual description of a variant; `NC_000011.9:g.12345611G>A`.
 - `:`: (double colon) is used to describe adjoined transcripts from gene fusions ([RNA Deletion-insertion](RNA/delins.md)) and to designate break point junctions creating a ring chromosome ([DNA Complex (HGVS/ISCN)](DNA/complex.md)).
 - `( )` (parentheses) are used to indicate uncertainties and predicted consequences; `NC_000023.9:g.(123456_234567)_(345678_456789)del`, `p.(Ser123Arg)`.<br>

--- a/docs/recommendations/grammar.md
+++ b/docs/recommendations/grammar.md
@@ -12,10 +12,10 @@ We recognize that most users of HGVS will not want to concern themselves with th
 
 - A grammar specifies the valid syntax for a string of characters. A _symbol_ is a grammatical classification that aids parsing.
 - There are two kinds of symbols: a _literal symbol_ represents verbatim text, and a _non-terminal symbol_ represents a named concept like "an integer sequence position". [more](https://en.wikipedia.org/wiki/Terminal_and_nonterminal_symbols)
-- Literal symbols are specified in double quotes. For example, `"A"`` means that an "A" character is accepted as input (and nothing else).
+- Literal symbols are specified in double quotes. For example, `"A"` means that an "A" character is accepted as input (and nothing else).
 - A "pipe" (`|`) separates alternatives. For example `"A" | "B"` accepts a single "A" or "B" character (and nothing else).
 - Symbols (of either type) may be concatenated. For example, `digit digit` matches a two-digit number. (Note: HGVS Nomenclature uses a common variant of EBNF in which concatenation is implied by adjacent symbols. Other EBNF variants require a comma between concatenated symbols.)
-- A _production rule_ defines a non-terminal symbol as a pattern of other symbols. For example, `digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"` says that `digit` is made of "0" or "1" or "2", etc. Similarly, `two_digit_dumber = digit digit` defines a two_digit_number non-terminal symbol as being composed of two adjacent digits.
+- A _production rule_ defines a non-terminal symbol as a pattern of other symbols. For example, `digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"` says that `digit` is made of "0" or "1" or "2", etc. Similarly, `two_digit_number = digit digit` defines a two_digit_number non-terminal symbol as being composed of two adjacent digits.
 - _Modifiers_ are used to indicate cardinality: `*` indicates zero or more of the preceding rule or symbol; `+` indicates one or more; and `?` denotes zero or one (i.e., optional). For example, `number = digit+` recognizes any sequence of digits without sign or decimal point.
 - Parentheses may be used to group a subexpression. For example, `"A" ( "B" | "C" )` accepts "AB" or "AC", and nothing else.
 - Square brackets indicate optional syntax. For example, `sign = "+" | "-"` and `number = [sign] digit+` allow numbers to be defined as any sequence of digits, optionally with a single prefix sign.


### PR DESCRIPTION
### Fix several typos on the website and in examples
- Only complex insertions need square brackets.
- Fix old syntax; `del(15)` has been replaced by `delN[15]`.
- Fix typos in a complex variant, although it's still invalid.
  - I noticed the variant because the positions were in the wrong order. However, based on the text, I could determine what was most likely meant.
  - However, I had to fix the text as well, as that contained a typo, too.
  - Finally, the variant still isn't valid since that reference sequence doesn't have exon endings at those positions. I have no clue what the source of this description is.
- Fix two forgotten prefixes (`c.` and `g.`).
- Fix some typos on the grammar page.